### PR TITLE
fix deprecated asdict() call

### DIFF
--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -93,8 +93,8 @@ class Animation:
         """
 
         new_state = {
-            'camera': self.viewer.camera.asdict(),
-            'dims': self.viewer.dims.asdict(),
+            'camera': self.viewer.camera.dict(),
+            'dims': self.viewer.dims.dict(),
         }
 
         # Log transform zoom for linear interpolation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 imageio
-napari>=0.4.4
+napari>=0.4.5
 napari-plugin-engine>=0.1.9
 numpy
 qtpy


### PR DESCRIPTION
as mentioned in #11 the `Viewer.dims.asdict()` method is now deprecated - updated to `Viewer.dims.dict()` to fix