### PR TITLE
add ability to animate layer attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ animation.capture_keyframe()
 animation.animate('demo.mov', canvas_only=False)
 ```
 
+## Is everything animate-able?
+
+Unfortunately, not yet! Currently we capture and animate differences in the following 
+objects
+
+- `Viewer.camera`
+- `Viewer.dims`
+- `Layer.scale`
+- `Layer.translate`
+- `Layer.rotate`
+- `Layer.shear`
+- `layer.opacity`
+- `Layer.blending`
+- `Layer.visible`
+
+
 ## Contributing
 
 Contributions are very welcome. Tests and additional infrastructure are being setup.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ animation.animate('demo.mov', canvas_only=False)
 
 ## Is everything animate-able?
 
-Unfortunately, not yet! Currently we capture and animate differences in the following 
-objects
+Unfortunately, not yet! Currently differences in the following objects are tracked by the `Animation` class
 
 - `Viewer.camera`
 - `Viewer.dims`
@@ -85,6 +84,7 @@ objects
 - `Layer.blending`
 - `Layer.visible`
 
+Support for more layer attributes will be added in future releases.
 
 ## Contributing
 

--- a/napari_animation/_tests/conftest.py
+++ b/napari_animation/_tests/conftest.py
@@ -3,6 +3,7 @@ discovery at test time.
 https://docs.pytest.org/en/stable/fixture.html
 """
 import pytest
+import numpy as np
 
 from napari_animation import Animation
 
@@ -31,3 +32,22 @@ def viewer_state(empty_animation):
 @pytest.fixture
 def key_frames(animation_with_key_frames):
     return animation_with_key_frames.key_frames
+
+
+@pytest.fixture
+def image_animation(make_napari_viewer):
+    viewer = make_napari_viewer()
+    viewer.add_image(np.random.random((28, 28)))
+    animation = Animation(viewer)
+    return animation
+
+
+@pytest.fixture
+def layer_state(image_animation):
+    image_animation.capture_keyframe()
+    return image_animation.key_frames[0]['viewer']['layers']
+
+
+
+
+

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -5,6 +5,17 @@ import pytest
 
 from napari_animation import Animation
 
+CAPTURED_LAYER_ATTRIBUTES = [
+    'name',
+    'scale',
+    'translate',
+    'rotate',
+    'shear',
+    'opacity',
+    'blending',
+    'visible'
+]
+
 
 def test_animation(make_napari_viewer):
     """Test creation of an animation class."""
@@ -78,7 +89,7 @@ def test_thumbnail_generation(empty_animation):
 )  # noqa: E501
 @pytest.mark.parametrize("ext", [".mp4", ".mov", ""])
 def test_animate_filenames(
-    frame_gen, get_writer, imsave, animation_with_key_frames, ext, tmp_path
+        frame_gen, get_writer, imsave, animation_with_key_frames, ext, tmp_path
 ):
     """Test that Animation.animate() produces files with correct filenames"""
     output_filename = tmp_path / f"test{ext}"
@@ -91,3 +102,10 @@ def test_animate_filenames(
         expected = [output_filename / f"test_{i}.png" for i in range(30)]
         saved_files = [call[0][0] for call in imsave.call_args_list]
         assert saved_files == expected
+
+
+@pytest.mark.parametrize('attribute', CAPTURED_LAYER_ATTRIBUTES)
+def test_layer_attribute_capture(layer_state, attribute):
+    """Test that 'attribute' is captured in the layer state dictionary"""
+    for layer_state_dict in layer_state.values():
+        assert attribute in layer_state_dict.keys()

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -118,27 +118,11 @@ class Animation:
         self.viewer.dims.update(state['dims'])
         self._set_layer_state(state['layers'])
 
-    @property
-    def layers(self):
-        return self.viewer.layers
-
-    def _layer_names(self):
-        return [layer.name for layer in self.layers]
-
-    @property
-    def layer_attributes(self):
-        attributes = (
-            'visible',
-            'opacity',
-            'blending',
-        )
-        return attributes
-
     def _get_layer_state(self):
         """Store layer state in a dict of dicts {layer.name: state}
         """
         layer_state = {
-            layer.name: layer._get_base_state() for layer in self.layers
+            layer.name: layer._get_base_state() for layer in self.viewer.layers
         }
         # remove metadata from layer_state dicts
         for state in layer_state.values():

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -96,6 +96,7 @@ class Animation:
         new_state = {
             'camera': self.viewer.camera.dict(),
             'dims': self.viewer.dims.dict(),
+            'layers': self._get_layer_state(),
         }
 
         # Log transform zoom for linear interpolation
@@ -116,6 +117,34 @@ class Animation:
 
         self.viewer.camera.update(camera_state)
         self.viewer.dims.update(state['dims'])
+        self._set_layer_state(state['layers'])
+
+    def _layer_names(self):
+        return [layer.name for layer in self.viewer.layers]
+
+    def _get_layer_visibility(self):
+        return {layer_name: self.viewer.layers[layer_name].visible for layer_name in
+                self._layer_names()}
+
+    def _get_layer_opacity(self):
+        return {layer_name: self.viewer.layers[layer_name].opacity for layer_name in
+                self._layer_names()}
+
+    def _get_layer_state(self):
+        """Store layer state attributes in a dict of dicts
+        dict keys are attribute names of the layers
+        dict values are a dict of form {layer_name: value} for each layer
+        """
+        layer_state = {
+            'visibile': self._get_layer_visibility(),
+            'opacity': self._get_layer_opacity()
+        }
+        return layer_state
+
+    def _set_layer_state(self, layer_state):
+        for attribute_name, value in layer_state.items():
+            for layer_name, attribute_value in value.items():
+                self.viewer.layers[layer_name].__setattr__(attribute_name, attribute_value)
 
     def _state_generator(self):
         if len(self.key_frames) < 2:

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -138,12 +138,13 @@ class Animation:
     def _get_layer_state(self):
         """Store layer state in a dict of dicts {layer.name: state}
         """
-        return {layer.name: layer._get_state() for layer in self.layers}
+        return {layer.name: layer._get_base_state() for layer in self.layers}
 
     def _set_layer_state(self, layer_state):
         for layer_name, layer_state in layer_state.items():
             layer = self.viewer.layers[layer_name]
-            for key, value in layer_state:
+            print(layer_state)
+            for key, value in layer_state.items():
                 setattr(layer, key, value)
 
     def _state_generator(self):

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -126,16 +126,6 @@ class Animation:
     def _layer_names(self):
         return [layer.name for layer in self.layers]
 
-    def _get_layer_attribute(self, attribute_name):
-        """Store layer attributes for all layers in a dict
-        key is layer name, value is named attribute from that layer
-        """
-        layer_attribute = {
-            layer_name: self.layers[layer_name].__getattribute__(attribute_name)
-            for layer_name in self._layer_names()
-        }
-        return layer_attribute
-
     @property
     def layer_attributes(self):
         attributes = (
@@ -146,19 +136,15 @@ class Animation:
         return attributes
 
     def _get_layer_state(self):
-        """Store layer state in a dict of dicts
-        dict keys are attribute names of the layers
-        dict values are a dict of form {layer_name: value} for each layer
+        """Store layer state in a dict of dicts {layer.name: state}
         """
-        layer_state = {
-            a: self._get_layer_attribute(a) for a in self.layer_attributes
-        }
-        return layer_state
+        return {layer.name: layer._get_state() for layer in self.layers}
 
     def _set_layer_state(self, layer_state):
-        for attribute_name, value in layer_state.items():
-            for layer_name, attribute_value in value.items():
-                self.viewer.layers[layer_name].__setattr__(attribute_name, attribute_value)
+        for layer_name, layer_state in layer_state.items():
+            layer = self.viewer.layers[layer_name]
+            for key, value in layer_state:
+                setattr(layer, key, value)
 
     def _state_generator(self):
         if len(self.key_frames) < 2:

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -119,25 +119,39 @@ class Animation:
         self.viewer.dims.update(state['dims'])
         self._set_layer_state(state['layers'])
 
+    @property
+    def layers(self):
+        return self.viewer.layers
+
     def _layer_names(self):
-        return [layer.name for layer in self.viewer.layers]
+        return [layer.name for layer in self.layers]
 
-    def _get_layer_visibility(self):
-        return {layer_name: self.viewer.layers[layer_name].visible for layer_name in
-                self._layer_names()}
+    def _get_layer_attribute(self, attribute_name):
+        """Store layer attributes for all layers in a dict
+        key is layer name, value is named attribute from that layer
+        """
+        layer_attribute = {
+            layer_name: self.layers[layer_name].__getattribute__(attribute_name)
+            for layer_name in self._layer_names()
+        }
+        return layer_attribute
 
-    def _get_layer_opacity(self):
-        return {layer_name: self.viewer.layers[layer_name].opacity for layer_name in
-                self._layer_names()}
+    @property
+    def layer_attributes(self):
+        attributes = (
+            'visible',
+            'opacity',
+            'blending',
+        )
+        return attributes
 
     def _get_layer_state(self):
-        """Store layer state attributes in a dict of dicts
+        """Store layer state in a dict of dicts
         dict keys are attribute names of the layers
         dict values are a dict of form {layer_name: value} for each layer
         """
         layer_state = {
-            'visibile': self._get_layer_visibility(),
-            'opacity': self._get_layer_opacity()
+            a: self._get_layer_attribute(a) for a in self.layer_attributes
         }
         return layer_state
 

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -137,7 +137,13 @@ class Animation:
     def _get_layer_state(self):
         """Store layer state in a dict of dicts {layer.name: state}
         """
-        return {layer.name: layer._get_base_state() for layer in self.layers}
+        layer_state = {
+            layer.name: layer._get_base_state() for layer in self.layers
+        }
+        # remove metadata from layer_state dicts
+        for state in layer_state.values():
+            state.pop('metadata')
+        return layer_state
 
     def _set_layer_state(self, layer_state):
         for layer_name, layer_state in layer_state.items():

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -1,14 +1,13 @@
 from copy import deepcopy
 from pathlib import Path
-import os
 
 import imageio
 import numpy as np
+from scipy import ndimage as ndi
+
 from napari.layers.utils.layer_utils import convert_to_uint8
 from napari.utils.events import EventedList
 from napari.utils.io import imsave
-from scipy import ndimage as ndi
-
 from .utils import interpolate_state
 
 
@@ -76,13 +75,13 @@ class Animation:
             Key-frame to visualize
         """
         self.frame = frame
-        self.set_to_current_keyframe()
+        if len(self.key_frames) > 0 and self.frame > -1:
+            self._set_viewer_state(self.key_frames[frame]['viewer'])
 
     def set_to_current_keyframe(self):
         """Set the viewer to the current key-frame
         """
-        if len(self.key_frames) > 0 and self.frame > -1:
-            self._set_viewer_state(self.key_frames[self.frame]['viewer'])
+        self._set_viewer_state(self.key_frames[self.frame]['viewer'])
 
     def _get_viewer_state(self):
         """Capture current viewer state
@@ -143,7 +142,6 @@ class Animation:
     def _set_layer_state(self, layer_state):
         for layer_name, layer_state in layer_state.items():
             layer = self.viewer.layers[layer_name]
-            print(layer_state)
             for key, value in layer_state.items():
                 setattr(layer, key, value)
 


### PR DESCRIPTION
This PR adds some machinery for getting and setting layer state, allowing changes in layer attributes to be animated.

I tried to write this in a general way so it can be easily extended, for now the only attributes included for animation are `Layer.visible`, `Layer.opacity` and `Layer.blending` which seem to work just fine!

https://user-images.githubusercontent.com/7307488/110219132-567ac980-7eb5-11eb-80bf-5f54236166af.mp4

