### PR TITLE
Fix key-binding to move across frames

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -140,12 +140,14 @@ class AnimationWidget(QWidget):
 
         new_frame = (self.animation.frame + 1) % len(self.animation.key_frames)
         self.animation.set_to_keyframe(new_frame)
+        self.keyframesListWidget.setCurrentRow(new_frame)
 
     def _key_back_frame(self, event=None):
         """Go backwards in key-frame list"""
 
         new_frame = (self.animation.frame - 1) % len(self.animation.key_frames)
         self.animation.set_to_keyframe(new_frame)
+        self.keyframesListWidget.setCurrentRow(new_frame)
 
     def _save_callback(self, event=None):
         SaveAnimationDialog(self.animation.animate, parent=self).exec_()

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -76,7 +76,7 @@ class Animation:
         """
         self.frame = frame
         if len(self.key_frames) > 0 and self.frame > -1:
-            self._set_viewer_state(self.key_frames[frame])
+            self._set_viewer_state(self.key_frames[frame]['viewer'])
 
     def set_to_current_keyframe(self):
         """Set the viewer to the current key-frame


### PR DESCRIPTION
This is a tiny PR which fixes the key-bindings Alt-a and Alt-b. First, because of a bug (missing call to 'viewer' key from the state dictionary) the key-bindings were not functional. Second, once that was fixed I realized that the selection of the key-frame widget row was not updating when moving across key-frames, and this PR fixes that as well.