### PR TITLE
conftest.py config + interpolation tests

### DIFF
--- a/napari_animation/_tests/conftest.py
+++ b/napari_animation/_tests/conftest.py
@@ -3,13 +3,13 @@ discovery at test time.
 https://docs.pytest.org/en/stable/fixture.html
 """
 import pytest
-from napari.utils._testsupport import make_napari_viewer  # noqa: F401
 
 from napari_animation import Animation
 
 
 @pytest.fixture
-def empty_animation(make_napari_viewer):  # noqa: F811
+def empty_animation(make_napari_viewer):
+    # make_napari_viewer fixture is provided by napari
     viewer = make_napari_viewer()
     animation = Animation(viewer)
     return animation

--- a/napari_animation/_tests/conftest.py
+++ b/napari_animation/_tests/conftest.py
@@ -1,3 +1,7 @@
+"""Test configuration for sharing fixtures across multiple files with automatic
+discovery at test time.
+https://docs.pytest.org/en/stable/fixture.html
+"""
 import pytest
 from napari.utils._testsupport import make_napari_viewer  # noqa: F401
 
@@ -12,7 +16,7 @@ def empty_animation(make_napari_viewer):  # noqa: F811
 
 
 @pytest.fixture
-def animation_with_keyframes(empty_animation):
+def animation_with_key_frames(empty_animation):
     for i in range(2):
         empty_animation.capture_keyframe()
         empty_animation.viewer.camera.zoom *= 2
@@ -22,3 +26,8 @@ def animation_with_keyframes(empty_animation):
 @pytest.fixture
 def viewer_state(empty_animation):
     return empty_animation._get_viewer_state()
+
+
+@pytest.fixture
+def key_frames(animation_with_key_frames):
+    return animation_with_key_frames.key_frames

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -5,8 +5,6 @@ import pytest
 
 from napari_animation import Animation
 
-from .fixtures import make_napari_viewer, empty_animation, animation_with_keyframes, viewer_state
-
 
 def test_animation(make_napari_viewer):
     """Test creation of an animation class."""
@@ -21,12 +19,12 @@ def test_capture_key_frame(empty_animation):
     assert len(animation.key_frames) == 0
     animation.capture_keyframe()
     assert len(animation.key_frames) == 1
-    assert 'viewer' in animation.key_frames[0].keys()
+    assert "viewer" in animation.key_frames[0].keys()
 
 
-def test_set_to_key_frame(animation_with_keyframes):
+def test_set_to_key_frame(animation_with_key_frames):
     """Test Animation.set_to_key_frame()"""
-    animation = animation_with_keyframes
+    animation = animation_with_key_frames
     for i in range(2):
         animation.set_to_keyframe(i)
         assert animation.frame == i
@@ -37,27 +35,29 @@ def test_get_viewer_state(empty_animation):
     animation = empty_animation
     state = animation._get_viewer_state()
     assert isinstance(state, dict)
-    assert all([item in state.keys() for item in ('camera', 'dims')])
+    assert all([item in state.keys() for item in ("camera", "dims")])
 
     # check that log transform has been applied to zoom
-    assert state['camera']['zoom'] == np.log10(animation.viewer.camera.zoom)
+    assert state["camera"]["zoom"] == np.log10(animation.viewer.camera.zoom)
 
 
-def test_set_viewer_state(animation_with_keyframes, viewer_state):
+def test_set_viewer_state(animation_with_key_frames, viewer_state):
     """Test Animation._set_viewer_state()"""
-    animation = animation_with_keyframes
+    animation = animation_with_key_frames
     current_state = animation._get_viewer_state()
     animation._set_viewer_state(viewer_state)
 
     animation_dims_state = animation.viewer.dims.dict()
     animation_camera_state = animation.viewer.camera.dict()
 
-    assert animation_dims_state == current_state['dims']
-    for key in ('center', 'angles', 'interactive'):
-        assert animation_camera_state[key] == current_state['camera'][key]
+    assert animation_dims_state == current_state["dims"]
+    for key in ("center", "angles", "interactive"):
+        assert animation_camera_state[key] == current_state["camera"][key]
 
     # check that log transform is undone on zoom
-    assert animation_camera_state['zoom'] == np.power(10, current_state['camera']['zoom'])
+    assert animation_camera_state["zoom"] == np.power(
+        10, current_state["camera"]["zoom"]
+    )
 
 
 def test_thumbnail_generation(empty_animation):
@@ -71,20 +71,23 @@ def test_thumbnail_generation(empty_animation):
     assert thumbnail.min() >= 0
 
 
-@patch('napari_animation.animation.imsave')
-@patch('imageio.get_writer')
-@patch('napari_animation.Animation._frame_generator', return_value=['frame'] * 30)
-@pytest.mark.parametrize('ext', ['.mp4', '.mov', ''])
-def test_animate_filenames(frame_gen, get_writer, imsave, animation_with_keyframes, ext,
-                           tmp_path):
-    """Test that Animation.animate() produces files with the correct filenames"""
-    output_filename = tmp_path / f'test{ext}'
-    animation_with_keyframes.animate(output_filename)
-    if ext in ('.mp4', '.mov'):
+@patch("napari_animation.animation.imsave")
+@patch("imageio.get_writer")
+@patch(
+    "napari_animation.Animation._frame_generator", return_value=["frame"] * 30
+)  # noqa: E501
+@pytest.mark.parametrize("ext", [".mp4", ".mov", ""])
+def test_animate_filenames(
+    frame_gen, get_writer, imsave, animation_with_key_frames, ext, tmp_path
+):
+    """Test that Animation.animate() produces files with correct filenames"""
+    output_filename = tmp_path / f"test{ext}"
+    animation_with_key_frames.animate(output_filename)
+    if ext in (".mp4", ".mov"):
         expected_filename = output_filename
         saved_filename = get_writer.call_args[0][0]
         assert saved_filename == expected_filename
-    elif ext == '':
-        expected = [output_filename / f'test_{i}.png' for i in range(30)]
-        saved_files = ([call[0][0] for call in imsave.call_args_list])
+    elif ext == "":
+        expected = [output_filename / f"test_{i}.png" for i in range(30)]
+        saved_files = [call[0][0] for call in imsave.call_args_list]
         assert saved_files == expected

--- a/napari_animation/_tests/test_utils.py
+++ b/napari_animation/_tests/test_utils.py
@@ -1,0 +1,64 @@
+import pytest
+
+from ..utils import (
+    _interpolate_bool,
+    _interpolate_float,
+    _interpolate_int,
+    interpolate_state,
+)
+
+
+@pytest.mark.parametrize("fraction", [0, 0.2, 0.4, 0.6, 0.8, 1])
+def test_interpolate_state(key_frames, fraction):
+    """Check that state interpolation works"""
+    initial_state = key_frames[0]["viewer"]
+    final_state = key_frames[1]["viewer"]
+    result = interpolate_state(initial_state, final_state, fraction)
+    assert len(result) == len(initial_state)
+    if fraction == 0:
+        assert result == initial_state
+    elif fraction == 1:
+        assert result == final_state
+    else:
+        # zoom is the only property modified in the key_frame fixture, check it
+        # has been interpolated properly
+        def get_zoom(state):
+            return state["camera"]["zoom"]
+
+        initial_zoom, final_zoom, result_zoom = (
+            get_zoom(state) for state in (initial_state, final_state, result)
+        )
+        assert result_zoom == _interpolate_float(
+            initial_zoom, final_zoom, fraction
+        )  # noqa: E501
+
+
+@pytest.mark.parametrize("a", [0.0, 0])
+@pytest.mark.parametrize("b", [1.0, 1])
+@pytest.mark.parametrize("fraction", [0, 0.0, 0.5, 1.0, 1])
+def test_interpolate_float(a, b, fraction):
+    """Check that interpolation of floats produces valid output"""
+    result = _interpolate_float(a, b, fraction)
+    assert isinstance(result, float)
+    assert result == fraction
+
+
+@pytest.mark.parametrize("a", [0.0, 0])
+@pytest.mark.parametrize("b", [100.0, 100])
+@pytest.mark.parametrize("fraction", [0, 0.0, 0.5, 1.0, 1])
+def test_interpolate_int(a, b, fraction):
+    """Check that integer interpolation produces integers"""
+    result = _interpolate_int(a, b, fraction)
+    assert isinstance(result, int)
+    assert result == fraction * b
+
+
+@pytest.mark.parametrize("a", [True, False])
+@pytest.mark.parametrize("b", [True, False])
+@pytest.mark.parametrize("fraction", [0, 0.25, 0.75, 1])
+def test_interpolate_bool(a, b, fraction):
+    result = _interpolate_bool(a, b, fraction)
+    if fraction < 0.5:
+        assert result == a
+    else:
+        assert result == b

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -1,7 +1,3 @@
-from copy import deepcopy
-
-import numpy as np
-
 from .easing import Easing
 
 
@@ -41,15 +37,20 @@ def interpolate_state(initial_state, final_state, fraction):
     elif isinstance(initial_state, int) and isinstance(final_state, int):
         return _interpolate_int(initial_state, final_state, fraction)
 
-    elif isinstance(initial_state, (list, tuple)) and isinstance(final_state, (list, tuple)):
-        return tuple(interpolate_state(v0, v1, fraction) for v0, v1 in zip(initial_state, final_state))
+    elif isinstance(initial_state, (list, tuple)) and isinstance(
+        final_state, (list, tuple)
+    ):
+        return tuple(
+            interpolate_state(v0, v1, fraction)
+            for v0, v1 in zip(initial_state, final_state)
+        )
 
     else:
         return _interpolate_bool(initial_state, final_state, fraction)
 
 
 def _interpolate_float(a, b, fraction):
-    return a + (b - a) * fraction
+    return float(a + (b - a) * fraction)
 
 
 def _interpolate_int(a, b, fraction):
@@ -63,6 +64,6 @@ def _interpolate_bool(a, b, fraction):
         return b
 
 
-def _easing_func_to_name(func):
-    [name] = [e.name for e in Easing if e.value is func]
+def _easing_func_to_name(easing_function):
+    [name] = [e.name for e in Easing if e.value is easing_function]
     return name


### PR DESCRIPTION
There were a couple of commits that got lost from #34 (pushes keep failing when I'm on the VPN, nightmare!) - I've added those here. 

The changes are
- configuring conftest.py for automatic fixture discovery at test time
- dropping the import of `make_napari_viewer` in favour of a comment (thanks @tlambert03 !)