### PR TITLE
Reduce duplicated widget name

### DIFF
--- a/examples/interactive_animation.py
+++ b/examples/interactive_animation.py
@@ -5,17 +5,13 @@ add_image APIs
 
 from skimage import data
 from scipy import ndimage as ndi
-from napari_animation import AnimationWidget
 import napari
 
 
-with napari.gui_qt():
-    blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=3)
-    viewer = napari.view_image(blobs.astype(float), name='blobs')
-    labeled = ndi.label(blobs)[0]
-    viewer.add_labels(labeled, name='blob ID')
+blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=3)
+viewer = napari.view_image(blobs.astype(float), name='blobs')
+labeled = ndi.label(blobs)[0]
+viewer.add_labels(labeled, name='blob ID')
 
-    animation_widget = AnimationWidget(viewer)
-    viewer.window.add_dock_widget(animation_widget, area='right')
-    viewer.update_console({'animation': animation_widget.animation})
-
+viewer.window.add_plugin_dock_widget('animation')
+napari.run()

--- a/napari_animation/_hookimpls.py
+++ b/napari_animation/_hookimpls.py
@@ -4,4 +4,4 @@ from ._qt import AnimationWidget
 
 @napari_hook_implementation
 def napari_experimental_provide_dock_widget():
-    return AnimationWidget
+    return (AnimationWidget, {'name': 'Wizard'})

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -45,8 +45,6 @@ class AnimationWidget(QWidget):
         self._layout = QVBoxLayout()
         self.setLayout(self._layout)
 
-        self._layout.addWidget(QLabel('Animation Wizard', parent=self))
-
         self._init_keyframes_list_control_widget()
         self._init_keyframes_list_widget()
         self._init_frame_widget()


### PR DESCRIPTION
Now that napari shows the names of dock widgets this PR drops the extra animation wizard label.

Before:

<img width="1200" alt="Screen Shot 2021-04-18 at 1 27 08 PM" src="https://user-images.githubusercontent.com/6531703/115159814-cd28ec00-a049-11eb-817b-7f1413fba02b.png">

After:

<img width="1200" alt="Screen Shot 2021-04-18 at 1 24 39 PM" src="https://user-images.githubusercontent.com/6531703/115159742-758a8080-a049-11eb-8da4-5dd89d6105e8.png">

It also changes the example to use `add_plugin_dock_widget`.

@alisterburt can you give this a review/ let me know what you think. Thanks!!