### PR TITLE
Add equality check to avoid expensive redraws

### DIFF
--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -143,7 +143,10 @@ class Animation:
         for layer_name, layer_state in layer_state.items():
             layer = self.viewer.layers[layer_name]
             for key, value in layer_state.items():
-                setattr(layer, key, value)
+                original_value = getattr(layer, key)
+                # Only set if value differs to avoid expensive redraws
+                if not np.array_equal(original_value, value):
+                    setattr(layer, key, value)
 
     def _state_generator(self):
         self._validate_animation()


### PR DESCRIPTION
A simple equality check when setting layer properties solves #54 - we go back to instant keyframe switches!

We can think about hashing states if we notice performance issues down the line

@sofroniewn @guiwitz I think this should be added before release of 0.0.1 if you find time to review/test

edit: np.array_equal is used as it handles both normal and array comparisons