### PR TITLE
update frame number on drop in KeyFramesListWidget

### DIFF
--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -42,6 +42,7 @@ class KeyFramesListWidget(QListWidget):
         """
         super().dropEvent(event)
         self._reorder_backend()
+        self._update_frame_number()
 
     def _selection_callback(self, event):
         self._update_frame_number()


### PR DESCRIPTION
Previously, dropping a key-frame in the `KeyFramesListWidget` would not update the current key-frame index stored in the `Animation` - this is fixed in this PR