### PR TITLE
Selection callback fix

### DIFF
--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -46,8 +46,9 @@ class KeyFramesListWidget(QListWidget):
 
     def _selection_callback(self):
         self._update_frame_number()
-        self.animation.set_to_current_keyframe()
-        self.parentWidget()._update_frame_widget_from_animation()
+        if self.animation.frame != -1:
+            self.animation.set_to_current_keyframe()
+            self.parentWidget()._update_frame_widget_from_animation()
 
     def _add(self, event):
         """Generate QListWidgetItem for current keyframe, store its unique id and add it to self"""

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -62,8 +62,10 @@ class Animation:
         }
 
         if insert or self.frame == -1:
-            self.key_frames.insert(self.frame + 1, new_state)
-            self.frame += 1
+            current_frame = self.frame
+            self.key_frames.insert(current_frame + 1, new_state)
+            self.frame = current_frame + 1
+
         else:
             self.key_frames[self.frame] = new_state
 


### PR DESCRIPTION
This PR fixes a bug which was an unintended side effect of #57

 `Animation.frame` would not be in sync with the selected frame in the `KeyFramesListWidget`, this meant modifying the `FrameWidget` would modify the wrong key-frame (or raise an `IndexError`)

Need to add Qt tests to check for this kind of error (#29)