### PR TITLE
Fix Easing

### DIFF
--- a/napari_animation/_qt/frame_widget.py
+++ b/napari_animation/_qt/frame_widget.py
@@ -30,7 +30,7 @@ class FrameWidget(QWidget):
 
     def get_easing_func(self):
         easing_name = str(self.easeComboBox.currentText())
-        easing_func = Easing[easing_name.upper()].value
+        easing_func = Easing[easing_name.upper()]
         return easing_func
 
     def update_from_animation(self):

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -31,6 +31,7 @@ def test_capture_key_frame(empty_animation):
     animation.capture_keyframe()
     assert len(animation.key_frames) == 1
     assert "viewer" in animation.key_frames[0].keys()
+    assert animation.key_frames[0]["ease"]
 
 
 def test_set_to_key_frame(animation_with_key_frames):

--- a/napari_animation/_tests/test_utils.py
+++ b/napari_animation/_tests/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
 
+from ..easing import Easing
 from ..utils import (
+    _easing_func_to_name,
     _interpolate_bool,
     _interpolate_float,
     _interpolate_int,
@@ -62,3 +64,12 @@ def test_interpolate_bool(a, b, fraction):
         assert result == a
     else:
         assert result == b
+
+
+@pytest.mark.parametrize(
+    "easing_function,expected",
+    [(Easing.LINEAR, "LINEAR"), (Easing.CIRCULAR, "CIRCULAR")],
+)
+def test_easing_func_to_name(easing_function, expected):
+    result = _easing_func_to_name(easing_function)
+    assert result == expected

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -9,6 +9,7 @@ from napari.utils.events import EventedList
 from napari.utils.io import imsave
 from scipy import ndimage as ndi
 
+from .easing import Easing
 from .utils import interpolate_state
 
 
@@ -32,7 +33,9 @@ class Animation:
         self.key_frames = EventedList()
         self.frame = -1
 
-    def capture_keyframe(self, steps=15, ease=None, insert=True, frame=None):
+    def capture_keyframe(
+        self, steps=15, ease=Easing.LINEAR, insert=True, frame=None
+    ):
         """Record current key-frame
         Parameters
         ----------
@@ -154,8 +157,7 @@ class Animation:
             # generate intermediate states between key-frames
             for interp in range(interpolation_steps):
                 fraction = interp / interpolation_steps
-                if ease is not None:
-                    fraction = ease(fraction)
+                fraction = ease(fraction)
                 state = interpolate_state(initial_state, final_state, fraction)
                 yield state
 

--- a/napari_animation/easing.py
+++ b/napari_animation/easing.py
@@ -276,3 +276,6 @@ class Easing(Enum):
     ELASTIC = partial(elastic_ease_in_out)
     BACK = partial(back_ease_in_out)
     BOUNCE = partial(bounce_ease_in_out)
+
+    def __call__(self, *args):
+        return self.value(*args)

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -63,5 +63,5 @@ def _interpolate_bool(a, b, fraction):
 
 
 def _easing_func_to_name(easing_function):
-    [name] = [e.name for e in Easing if e.value is easing_function]
+    [name] = [e.name for e in Easing if e is easing_function]
     return name


### PR DESCRIPTION
This makes Easing functions directly callable, for instance `Easing.LINEAR(a, b, fraction)` instead of `Easing.LINEAR.value(a, b, fraction)`.

Also, the `capture_keyframe` function now default the ease to `Easing.LINEAR` instead of `None`. It makes things more coherent overall and fixes #67.
