### PR TITLE
avoid triggering selection callback when moving AnimationSliderWidget

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -218,7 +218,7 @@ class AnimationWidget(QWidget):
             self.animationsliderWidget.cumulative_frame_count > new_frame
         ).argmax()
         new_key_frame -= 1  # to get the previous key frame
-        self.keyframesListWidget.setCurrentRow(new_key_frame)
+        self.keyframesListWidget.setCurrentRowBlockingSignals(new_key_frame)
 
     def _update_theme(self, event=None):
         """Update from the napari GUI theme"""

--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -166,3 +166,8 @@ class KeyFramesListWidget(QListWidget):
     def frontend_key_frames(self):
         for item in self.frontend_items:
             yield self._item_id_to_key_frame[id(item)]
+
+    def setCurrentRowBlockingSignals(self, *args):
+        self.blockSignals(True)
+        self.setCurrentRow(*args)
+        self.blockSignals(False)


### PR DESCRIPTION
fix for #66 

Updating the item selected in the `KeyFramesListWidget` when moving the `AnimationSliderWidget` had the unintended side effect of triggering the selection callback which set the key-frame - blocking signals temporarily fixes this 

before:
https://user-images.githubusercontent.com/7307488/116756299-c748e880-aa03-11eb-92f9-3e49d19ba795.mp4

after:
https://user-images.githubusercontent.com/7307488/116756303-c9ab4280-aa03-11eb-89a1-1c81421ae6b6.mp4
