### PR TITLE
interactive/scripted interplay fixes

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -116,7 +116,6 @@ class AnimationWidget(QWidget):
             self.animation, parent=self
         )
         self._layout.addWidget(self.keyframesListWidget)
-        self.keyframesListWidget.setEnabled(False)
 
     def _init_save_button(self):
         self.saveButton = QPushButton("Save Animation", parent=self)

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -102,14 +102,12 @@ class AnimationWidget(QWidget):
     def _init_frame_widget(self):
         self.frameWidget = FrameWidget(parent=self)
         self._layout.addWidget(self.frameWidget)
-        self.frameWidget.setEnabled(False)
 
     def _init_keyframes_list_control_widget(self):
         self.keyframesListControlWidget = KeyFrameListControlWidget(
             animation=self.animation, parent=self
         )
         self._layout.addWidget(self.keyframesListControlWidget)
-        self.keyframesListControlWidget.deleteButton.setEnabled(False)
 
     def _init_keyframes_list_widget(self):
         self.keyframesListWidget = KeyFramesListWidget(

--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -1,3 +1,5 @@
+from dataclasses import make_dataclass
+
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QIcon, QImage, QPixmap
 from qtpy.QtWidgets import QListWidget, QListWidgetItem
@@ -24,11 +26,19 @@ class KeyFramesListWidget(QListWidget):
         self._frame_count = 0
         self._item_id_to_key_frame = {}
         self._key_frame_id_to_item = {}
+        self._init_synchronise()
 
         self._connect_key_frame_callbacks()
         self.setDragDropMode(super().InternalMove)
 
         self.itemSelectionChanged.connect(self._selection_callback)
+
+    def _init_synchronise(self):
+        """Synchronise the KeyFramesListwidget with its animation on init"""
+        # Simulate events for adding existing items
+        Event = make_dataclass("Event", [("index", int), ("value", dict)])
+        for idx, key_frame in self.animation.key_frames:
+            self._add(Event(index=idx, value=key_frame))
 
     def _connect_key_frame_callbacks(self):
         """Connect events on the key frame list to their callbacks"""

--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -1,5 +1,3 @@
-from dataclasses import make_dataclass
-
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QIcon, QImage, QPixmap
 from qtpy.QtWidgets import QListWidget, QListWidgetItem
@@ -26,19 +24,11 @@ class KeyFramesListWidget(QListWidget):
         self._frame_count = 0
         self._item_id_to_key_frame = {}
         self._key_frame_id_to_item = {}
-        self._init_synchronise()
 
         self._connect_key_frame_callbacks()
         self.setDragDropMode(super().InternalMove)
 
         self.itemSelectionChanged.connect(self._selection_callback)
-
-    def _init_synchronise(self):
-        """Synchronise the KeyFramesListwidget with its animation on init"""
-        # Simulate events for adding existing items
-        Event = make_dataclass("Event", [("index", int), ("value", dict)])
-        for idx, key_frame in self.animation.key_frames:
-            self._add(Event(index=idx, value=key_frame))
 
     def _connect_key_frame_callbacks(self):
         """Connect events on the key frame list to their callbacks"""


### PR DESCRIPTION
This PR generally improves things around issue #52

The `AnimationWidget` instantiates an empty `Animation` on init and disables some functionality in the UI - if key-frames are captured in a script the callbacks associated with those captures are not called and as a consequence the UI ends up in a generally messy broken state. This PR stops disabling the functionality of various widgets on init leaving the UI in a working state after the example provided in #52 