### PR TITLE
Very minor fix ; frame type and delete callback

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -213,6 +213,7 @@ class AnimationWidget(QWidget):
             self.animationsliderWidget.cumulative_frame_count > new_frame
         ).argmax()
         new_key_frame -= 1  # to get the previous key frame
+        new_key_frame = int(new_key_frame) # to enable slicing a list with it
         self.keyframesListWidget.setCurrentRowBlockingSignals(new_key_frame)
         self.animation.frame = new_key_frame
 


### PR DESCRIPTION
Just a very minor fix ; the delete button callback wasn't working just after playing with the slider.

In cause, the frame attribute value was casted to a numpy type, and couldn't be used anymore for popping a frame out as in the delete button callback !