### PR TITLE
Fix bug in setting the animation writer options

### DIFF
--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -269,13 +269,13 @@ class Animation:
                 # create imageio writer. Handle separately imageio-ffmpeg extensions and
                 # gif extension which doesn't accept the quality parameter.
                 if path_obj.suffix in [
-                    "mov",
-                    "avi",
-                    "mpg",
-                    "mpeg",
-                    "mp4",
-                    "mkv",
-                    "wmv",
+                    ".mov",
+                    ".avi",
+                    ".mpg",
+                    ".mpeg",
+                    ".mp4",
+                    ".mkv",
+                    ".wmv",
                 ]:
                     writer = imageio.get_writer(
                         path,


### PR DESCRIPTION
Two types of ```imageio``` writers are used depending on the chosen file type. A series of file types (mov, avi etc) gives access to more options such as e.g. ```quality```. The problem is that the dot sign in the list of extensions used to check the desired format is missing. As the ```suffix``` parameter of a ```pathlib.Path``` object returns extensions *with* a dot, the more complex writer is just ignored. This is a silent bug as no error is produced and passed options like ```quality``` are just ignored. This PR fixes this problem.