### PR TITLE
Move requirements to setup.cfg, add dev environment setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-imageio
-imageio-ffmpeg
-napari>=0.4.5
-napari-plugin-engine>=0.1.9
-numpy
-qtpy
-scipy
+# requirements are in setup.cfg
+# https://caremad.io/posts/2013/07/setup-vs-requirement/
+
+-e ".[dev]"

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ dev =
     black
     flake8
     check-manifest
+    PyQt5>=5.12.3,!=5.15.0
     %(testing)s
 
    

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ url = https://github.com/napari/napari-animation
 download_url = https://github.com/napari/napari-animation
 license = BSD 3-Clause
 license_file = LICENSE
-description = A plugin to make animations with napari
+description = A plugin for making animations in napari
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Nicholas Sofroniew, Alister Burt, Guillaume Witz, Faris Abouakil, Talley Lambert
@@ -36,6 +36,18 @@ install_requires =
 	numpy
 	qtpy
 	scipy
+
+
+[options.extras_require]
+testing =
+    pytest
+dev =
+    pre-commit
+    black
+    flake8
+    check-manifest
+    %(testing)s
+
    
 
 [options.entry_points]


### PR DESCRIPTION
Mirroring napari, requirements are now specified in setup.cfg including a set of development requirements