### PR TITLE
skeleton docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,54 @@
+# Book settings
+# Learn more at https://jupyterbook.org/customize/config.html
+
+title: napari-animation
+author: The napari-animation team
+logo: images/logo.png
+only_build_toc_files: true
+
+# Force re-execution of notebooks on each build.
+# See https://jupyterbook.org/content/execute.html
+execute:
+  execute_notebooks: force
+
+# Information about where the book exists on the web
+repository:
+  url: https://github.com/napari/napari-animation # Online location of your book
+  path_to_book: docs # Optional path to your book, relative to the repository root
+  branch: main # Which branch of the repository should be used when creating links (optional)
+
+# Add GitHub buttons to your book
+# See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
+html:
+  use_issues_button: true
+  use_repository_button: true
+
+sphinx:
+  extra_extensions:
+    - sphinx.ext.viewcode
+    - sphinx.ext.napoleon
+    - sphinx.ext.autodoc
+    - sphinx_autodoc_typehints
+    - sphinx.ext.autosummary
+    - sphinx.ext.intersphinx
+
+  config:
+    autosummary_generate: True
+    autosummary_imported_members: True
+    html_theme: furo
+    pygments_style: solarized-dark
+#    templates_path:
+#        - '_templates'
+    intersphinx_mapping:
+      python:
+        - "https://docs.python.org/3"
+        - null
+      numpy:
+        - "https://docs.scipy.org/doc/numpy/"
+        - null
+      napari_plugin_engine:
+        - "https://napari-plugin-engine.readthedocs.io/en/latest/"
+        - "https://napari-plugin-engine.readthedocs.io/en/latest/objects.inv"
+      magicgui:
+        - "https://napari.org/magicgui/"
+        - "https://napari.org/magicgui/objects.inv"

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,0 +1,49 @@
+# Table of content
+# Learn more at https://jupyterbook.org/customize/toc.html
+#
+- file: index
+- file: developers/contributing
+#- file: guides/index
+#  sections:
+#    - file: guides/event_loop
+#    - file: guides/connecting_events
+#    - file: guides/threading
+#    - file: guides/magicgui
+#    - file: guides/perfmon
+#    - file: guides/rendering
+#
+#- file: plugins/index
+#  sections:
+#    - file: plugins/for_napari_developers
+#    - file: plugins/for_plugin_developers
+#    - file: plugins/hook_specifications
+#
+#- file: developers/index
+#  sections:
+#    - file: developers/team
+#    - file: developers/benchmarks
+#    - file: developers/code_of_conduct
+#    - file: developers/code_of_conduct_reporting
+#    - file: developers/contributing
+#    - file: developers/core_dev_guide
+#    - file: developers/docs
+#    - file: developers/governance
+#    - file: developers/mission_and_values
+#    - file: developers/release
+#    - file: developers/roadmap_0_3
+#    - file: developers/roadmap_0_3_retrospective
+#    - file: developers/roadmap_0_4
+#    - file: developers/testing
+#
+#- file: explanations/index
+#  sections:
+#    - file: explanations/docker
+#    - file: explanations/performance
+#    - file: explanations/rendering
+#
+#- file: release/index
+#
+#- file: api/index
+#  sections:
+#    - file: api/napari
+

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -1,0 +1,171 @@
+# Contributing Guide
+
+We welcome your contributions! Please see the provided steps below and never hesitate to contact us.
+
+If you are a new user, we recommend checking out the detailed [Github Guides](https://guides.github.com).
+
+## Setting up a development installation
+
+In order to make changes to `napari-animation`, you will need to [fork](https://guides.github.com/activities/forking/#fork) the
+[repository](https://github.com/napari/napari-animation).
+
+If you are not familiar with `git`, we recommend reading up on [this guide](https://guides.github.com/introduction/git-handbook/#basic-git).
+
+Clone the forked repository to your local machine and change directories:
+```sh
+git clone https://github.com/your-username/napari-animation.git
+cd napari-animation
+```
+
+Set the `upstream` remote to the base `napari` repository:
+```sh
+git remote add upstream https://github.com/napari/napari-animation.git
+```
+
+Install the package in editable mode, along with all of the developer tools
+```sh
+pip install -r requirements.txt
+```
+
+We use [`pre-commit`](https://pre-commit.com) to sort imports with
+[`isort`](https://github.com/timothycrosley/isort), format code with
+[`black`](https://github.com/psf/black), and lint with
+[`flake8`](https://github.com/PyCQA/flake8) automatically prior to each commit.
+To minmize test errors when submitting pull requests, please install `pre-commit`
+in your environment as follows:
+
+```sh
+pre-commit install
+```
+
+Upon committing, your code will be formatted according to our [`black`
+configuration](https://github.com/napari/napari-animation/blob/main/pyproject.toml). To learn more,
+see [`black`'s documentation](https://black.readthedocs.io/en/stable/).
+
+Code will also be linted to enforce the stylistic and logistical rules specified
+in our [`flake8` configuration](https://github.com/napari/napari/blob/master/setup.cfg), which currently ignores
+[E203](https://lintlyci.github.io/Flake8Rules/rules/E203.html),
+[E501](https://lintlyci.github.io/Flake8Rules/rules/E501.html),
+[W503](https://lintlyci.github.io/Flake8Rules/rules/W503.html) and
+[C901](https://lintlyci.github.io/Flake8Rules/rules/C901.html).  For information
+on any specific flake8 error code, see the [Flake8
+Rules](https://lintlyci.github.io/Flake8Rules/).  You may also wish to refer to
+the [PEP 8 style guide](https://www.python.org/dev/peps/pep-0008/).
+
+If you wish to tell the linter to ignore a specific line use the `# noqa`
+comment along with the specific error code (e.g. `import sys  # noqa: E402`) but
+please do not ignore errors lightly.
+
+## Translations
+
+Starting with version 0.4.7, napari codebase include internationalization
+(i18n) and now offers the possibility of installing language packs, which
+provide localization (l10n) enabling the user interface to be displayed in
+different languages.
+
+To learn more about the current languages that are in the process of
+translation, visit the [language packs repository](https://github.com/napari/napari-language-packs)
+
+To make your code translatable (localizable), please use the `trans` helper
+provided by the napari utilities.
+
+```python
+from napari.utils.translations import trans
+
+some_string = trans._("Localizable string")
+```
+
+To learn more, please see the [translations guide](https://napari.org/guides/stable/translations.html).
+
+## Making changes
+
+Create a new feature branch:
+```sh
+git checkout master -b your-branch-name
+```
+
+`git` will automatically detect changes to a repository.
+You can view them with:
+```sh
+git status
+```
+
+Add and commit your changed files:
+```sh
+git add my-file-or-directory
+git commit -m "my message"
+```
+
+## Tests
+
+We use unit tests and integration tests to ensure that
+napari-animation works as intended. Writing tests for new code is a critical part of
+keeping napari-animation maintainable as it grows.
+
+Check out the dedicated documentation on testing over at [napari.org](https://napari.org/developers/testing.html) that we recommend you
+read as you're working on your first contribution.
+
+### Help us make sure it's you
+
+Each commit you make must have a [GitHub-registered email](https://github.com/settings/emails)
+as the `author`. You can read more [here](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address).
+
+To set it, use `git config --global user.email your-address@example.com`.
+
+## Keeping your branches up-to-date
+
+Switch to the `master` branch:
+```sh
+git checkout master
+```
+
+Fetch changes and update `master`:
+```sh
+git pull upstream master --tags
+```
+
+This is shorthand for:
+```sh
+git fetch upstream master --tags
+git merge upstream/master
+```
+
+Update your other branches:
+```sh
+git checkout your-branch-name
+git merge master
+```
+
+## Sharing your changes
+
+Update your remote branch:
+```sh
+git push -u origin your-branch-name
+```
+
+You can then make a [pull-request](https://guides.github.com/activities/forking/#making-a-pull-request) to `napari`'s `master` branch.
+
+## Building the docs
+
+From the project root:
+```sh
+make docs
+```
+
+The docs will be built at `docs/_build/html`.
+
+Most web browsers will allow you to preview HTML pages.
+Try entering `file:///absolute/path/to/napari/docs/_build/html/index.html` in your address bar.
+
+To read more about the docs, how they're organized, and built, read {ref}`docs-dev`.
+
+## Code of conduct
+
+`napari` has a [Code of Conduct](CODE_OF_CONDUCT.md) that should be honored by everyone who participates in the `napari` community.
+
+## Questions, comments, and feedback
+
+If you have questions, comments, suggestions for improvement, or any other inquiries
+regarding the project, feel free to open an [issue](https://github.com/napari/napari/issues).
+
+Issues and pull-requests are written in [Markdown](https://guides.github.com/features/mastering-markdown/#what). You can find a comprehensive guide [here](https://guides.github.com/features/mastering-markdown/#syntax).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,111 @@
+# napari-animation (WIP under active development)
+
+[![License](https://img.shields.io/pypi/l/napari-animation.svg?color=green)](https://github.com/napari/napari-animation/raw/master/LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/napari-animation.svg?color=green)](https://pypi.org/project/napari-animation)
+[![Python Version](https://img.shields.io/pypi/pyversions/napari-animation.svg?color=green)](https://python.org)
+[![tests](https://github.com/sofroniewn/napari-animation/workflows/tests/badge.svg)](https://github.com/sofroniewn/napari-animation/actions)
+[![codecov](https://codecov.io/gh/sofroniewn/napari-animation/branch/master/graph/badge.svg)](https://codecov.io/gh/sofroniewn/napari-animation)
+
+**napari-animation** is a plugin for making animations in [napari].
+
+----------------------------------
+
+This [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.
+
+It is built off of great work from @guiwitz in [naparimovie](https://github.com/guiwitz/naparimovie) which was initially submitted to napari in [PR#851](https://github.com/napari/napari/pull/780).
+
+----------------------------------
+## Overview
+
+**napari-animation** provides a framework for the creation of animations in napari and features:
+- an easy to use GUI for interactive creation of animations
+- Python tools for programmatic creation of animations
+
+This plugin is currently pre-release and under active development. APIs are likely to change before it's first 0.0.1 release,
+but feedback and contributions are welcome.
+
+## Installation
+
+You can clone this repository with install locally with
+
+    pip install -e .
+
+## Examples
+Examples can be found in our [examples](examples) folder. Simple examples for both interactive and headless 
+use of the plugin follow.
+
+### Interactive
+**napari-animation** can be used interactively by creating an `AnimationWidget` from a napari `Viewer` and adding it to
+the viewer as a dock widget.
+
+```python
+from napari_animation import AnimationWidget
+
+animation_widget = AnimationWidget(viewer)
+viewer.window.add_dock_widget(animation_widget, area='right')
+```
+
+![AnimationWidget image](../resources/screenshot-animation-widget.png)
+
+### Headless
+**napari-animation** can also be run headless, allowing for reproducible, scripted creation of animations.
+
+```python
+from napari_animation import Animation
+
+animation = Animation(viewer)
+
+viewer.dims.ndisplay = 3
+viewer.camera.angles = (0.0, 0.0, 90.0)
+animation.capture_keyframe()
+viewer.camera.zoom = 2.4
+animation.capture_keyframe()
+viewer.camera.angles = (-7.0, 15.7, 62.4)
+animation.capture_keyframe(steps=60)
+viewer.camera.angles = (2.0, -24.4, -36.7)
+animation.capture_keyframe(steps=60)
+viewer.reset_view()
+viewer.camera.angles = (0.0, 0.0, 90.0)
+animation.capture_keyframe()
+animation.animate('demo.mov', canvas_only=False)
+```
+
+## Is everything animate-able?
+
+Unfortunately, not yet! Currently differences in the following objects are tracked by the `Animation` class
+
+- `Viewer.camera`
+- `Viewer.dims`
+- `Layer.scale`
+- `Layer.translate`
+- `Layer.rotate`
+- `Layer.shear`
+- `layer.opacity`
+- `Layer.blending`
+- `Layer.visible`
+
+Support for more layer attributes will be added in future releases.
+
+## Contributing
+
+Contributions are very welcome. Tests and additional infrastructure are being setup.
+
+## License
+
+Distributed under the terms of the [BSD-3] license,
+"napari-animation" is free and open source software
+
+## Issues
+
+If you encounter any problems, please [file an issue] along with a detailed description.
+
+[napari]: https://github.com/napari/napari
+[Cookiecutter]: https://github.com/audreyr/cookiecutter
+[@napari]: https://github.com/napari
+[BSD-3]: http://opensource.org/licenses/BSD-3-Clause
+[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin
+[file an issue]: https://github.com/sofroniewn/napari-animation/issues
+[napari]: https://github.com/napari/napari
+[tox]: https://tox.readthedocs.io/en/latest/
+[pip]: https://pypi.org/project/pip/
+[PyPI]: https://pypi.org/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+jupyter-book==0.10.2
+furo
+sphinx-autodoc-typehints


### PR DESCRIPTION
A skeleton of some documentation including

- copy of readme
- contributing guide modified from the napari contributing guide

Things still needed before merge
- [ ] #79 should merge so that contributing guide is accurate
- [ ] logo
- [ ] update readme to reflect pip installation
- [ ] tutorial for interactive animation
- [ ] github actions for deployment of built docs to `gh-pages` branch

To build
```
pip install docs/requirements.txt
jupyter-book build docs
```

