### PR TITLE
Stylesheet fix

### DIFF
--- a/napari_animation/_hookimpls.py
+++ b/napari_animation/_hookimpls.py
@@ -5,4 +5,8 @@ from ._qt import AnimationWidget
 
 @napari_hook_implementation
 def napari_experimental_provide_dock_widget():
-    return (AnimationWidget, {"name": "Wizard"})
+    widget_options = {
+        "name": "Wizard",
+        "add_vertical_stretch": False,
+    }
+    return AnimationWidget, widget_options

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -213,17 +213,18 @@ class AnimationWidget(QWidget):
             self.animationsliderWidget.cumulative_frame_count > new_frame
         ).argmax()
         new_key_frame -= 1  # to get the previous key frame
-        new_key_frame = int(new_key_frame) # to enable slicing a list with it
+        new_key_frame = int(new_key_frame)  # to enable slicing a list with it
         self.keyframesListWidget.setCurrentRowBlockingSignals(new_key_frame)
         self.animation.frame = new_key_frame
 
     def _update_theme(self, event=None):
         """Update from the napari GUI theme"""
+        from napari.qt import get_stylesheet
         from napari.utils.theme import get_theme, template
 
         # get theme and raw stylesheet from napari viewer
         theme = get_theme(self.viewer.theme)
-        raw_stylesheet = self.viewer.window.qt_viewer.raw_stylesheet
+        raw_stylesheet = get_stylesheet()
 
         # template and apply the primary stylesheet
         templated_stylesheet = template(raw_stylesheet, **theme)


### PR DESCRIPTION
fix broken plugin import due to deprecation of `qt_viewer.raw_stylesheet` in napari 0.4.8 napari/napari#2643 - fixed by mirroring the napari console implementation
https://github.com/napari/napari-console/blob/fd3a291331e052e591042850b56fd1db5815f784/napari_console/qt_console.py#L151-L171