### PR TITLE
Stylesheet fix take 2

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -47,9 +47,6 @@ class AnimationWidget(QWidget):
         self._add_keybind_callbacks()
         self._add_callbacks()
 
-        # Update theme
-        self._update_theme()
-
     def _init_ui(self):
         """Initialise user interface"""
         self._layout = QVBoxLayout()
@@ -87,7 +84,9 @@ class AnimationWidget(QWidget):
         self.animationsliderWidget.valueChanged.connect(
             self._move_animationslider_callback
         )
-        self.viewer.events.theme.connect(self._update_theme)
+        self.viewer.events.theme.connect(
+            lambda e: self.keyframesListWidget._update_theme(e.value)
+        )
 
     def _release_callbacks(self):
         """Release keys"""
@@ -113,6 +112,7 @@ class AnimationWidget(QWidget):
         self.keyframesListWidget = KeyFramesListWidget(
             self.animation, parent=self
         )
+        self.keyframesListWidget._update_theme(self.viewer.theme)
         self._layout.addWidget(self.keyframesListWidget)
 
     def _init_save_button(self):
@@ -217,23 +217,6 @@ class AnimationWidget(QWidget):
         self.keyframesListWidget.setCurrentRowBlockingSignals(new_key_frame)
         self.animation.frame = new_key_frame
 
-    def _update_theme(self, event=None):
-        """Update from the napari GUI theme"""
-        from napari.qt import get_stylesheet
-        from napari.utils.theme import get_theme, template
-
-        # get theme and raw stylesheet from napari viewer
-        theme = get_theme(self.viewer.theme)
-        raw_stylesheet = get_stylesheet()
-
-        # template and apply the primary stylesheet
-        templated_stylesheet = template(raw_stylesheet, **theme)
-        self.setStyleSheet(templated_stylesheet)
-
-        # update styling of KeyFramesListWidget
-        self.keyframesListWidget._update_theme(theme)
-
     def close(self):
         self._release_callbacks()
-        self.viewer.events.theme.disconnect(self._update_theme)
         super().close()

--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -118,15 +118,19 @@ class KeyFramesListWidget(QListWidget):
         else:
             return idxs[-1].row()
 
-    def _update_theme(self, theme):
+    def _update_theme(self, theme_name):
         """
         Update styling based on the napari theme dictionary and any other attributes
 
         Parameters
         ----------
-        theme : dict
-                theme dict from napari
+        theme : str
+            name of napari theme
         """
+        from napari.utils.theme import get_theme
+
+        theme = get_theme(theme_name)
+
         deselected_bg_color = theme["foreground"]
         deselected_bg_color_qss = (
             f"QListView::item:deselected"

--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -127,37 +127,33 @@ class KeyFramesListWidget(QListWidget):
         theme : str
             name of napari theme
         """
-        from napari.utils.theme import get_theme
+        from napari.utils.theme import get_theme, template
 
-        theme = get_theme(theme_name)
+        qss_template = """
+        QListView::item:deselected {
+            background-color: {{ foreground }};
+        }
+        QListView::item:selected {
+            background-color: {{ current }};
+        }
+        QListView {
+            background: transparent;
+        }
+        QListView::item {
+            margin: 0px;
+            padding: 0px;
+            min-height:
+            32px;
+            max-height: 32px;
+        }
+        QImage {
+            margin: 0px;
+            padding: 0px;
+            qproperty-alignment: AlignLeft;
+        }
+        """
 
-        deselected_bg_color = theme["foreground"]
-        deselected_bg_color_qss = (
-            f"QListView::item:deselected"
-            f"{{background-color: {deselected_bg_color};}}"
-        )
-
-        selected_bg_color = theme["current"]
-        selected_bg_color_qss = (
-            f"QListView::item:selected"
-            f"{{background-color: {selected_bg_color};}}"
-        )
-
-        transparent_background_qss = "QListView{background: transparent;}"
-
-        item_qss = (
-            "QListView::item{margin: 0px; padding: 0px; min-height: 32px; max-height: 32px;}"
-            "QImage{margin: 0px; padding: 0px; qproperty-alignment: AlignLeft;}"
-        )
-        style_sheet_components = [
-            deselected_bg_color_qss,
-            selected_bg_color_qss,
-            transparent_background_qss,
-            item_qss,
-        ]
-        style_sheet = "\n".join(style_sheet_components)
-
-        self.setStyleSheet(style_sheet)
+        self.setStyleSheet(template(qss_template, **get_theme(theme_name)))
         self.setIconSize(QSize(64, 64))
         self.setSpacing(2)
 


### PR DESCRIPTION
a little modification to the stylesheet strategy...

The only reason it was necessary to do all the manual theming in `napari-console`  is because `qt_console`, rather frustratingly, uses something _other_ than Qt's `setStylesheet` to set their stylesheet.  (see that they have a `self.style_sheet` attribute that we set [here](https://github.com/napari/napari-console/blob/fd3a291331e052e591042850b56fd1db5815f784/napari_console/qt_console.py#L162)) ... 
In all other cases, the widget will inherit the stylesheet of its parent.  So `AnimationWidget` will just naturally "look right" when docked in napari, no additional effort required.

`KeyFramesListWidget` does still need to update theme for now (but I'll submit another PR sometime that may simplify all that too)... here, I just made the stylesheet template look a little bit more like a stylesheet.  hope that's ok
