### PR TITLE
Set a range to the steps QSpinBox

### DIFF
--- a/napari_animation/_qt/frame_widget.py
+++ b/napari_animation/_qt/frame_widget.py
@@ -18,6 +18,7 @@ class FrameWidget(QWidget):
 
     def _init_steps(self):
         self.stepsSpinBox = QSpinBox()
+        self.stepsSpinBox.setRange(1, 100000);
         self.stepsSpinBox.setValue(15)
         self._layout.addRow("Steps", self.stepsSpinBox)
 


### PR DESCRIPTION
The QSpinBox for steps value from the widget was limited to a range of 0 to 99. I set it to a more coherent value of 1 to 100000. I arbitrarily chose this last value, corresponding to the biggest power often that fitted in the box while the widget was reduced to a minimal size.