### PR TITLE
Switching Animation to an EventedModel

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -22,7 +22,7 @@ class AnimationWidget(QWidget):
 
     Parameters
     ----------
-    viewer : napari.Viewer
+    _viewer : napari.Viewer
         napari viewer.
 
     Attributes
@@ -37,8 +37,8 @@ class AnimationWidget(QWidget):
         super().__init__(parent=parent)
 
         # Store reference to viewer and create animation
-        self.viewer = viewer
-        self.animation = Animation(self.viewer)
+        self._viewer = viewer
+        self.animation = Animation(self._viewer)
 
         # Initialise UI
         self._init_ui()
@@ -61,16 +61,12 @@ class AnimationWidget(QWidget):
     def _add_keybind_callbacks(self):
         """Bind keys"""
 
-        self.animation.viewer.bind_key(
-            "Alt-f", self._capture_keyframe_callback
-        )
-        self.animation.viewer.bind_key(
-            "Alt-r", self._replace_keyframe_callback
-        )
-        self.animation.viewer.bind_key("Alt-d", self._delete_keyframe_callback)
+        self._viewer.bind_key("Alt-f", self._capture_keyframe_callback)
+        self._viewer.bind_key("Alt-r", self._replace_keyframe_callback)
+        self._viewer.bind_key("Alt-d", self._delete_keyframe_callback)
 
-        self.animation.viewer.bind_key("Alt-a", self._key_adv_frame)
-        self.animation.viewer.bind_key("Alt-b", self._key_back_frame)
+        self._viewer.bind_key("Alt-a", self._key_adv_frame)
+        self._viewer.bind_key("Alt-b", self._key_back_frame)
 
     def _add_callbacks(self):
         """Establish callbacks"""
@@ -84,19 +80,19 @@ class AnimationWidget(QWidget):
         self.animationsliderWidget.valueChanged.connect(
             self._move_animationslider_callback
         )
-        self.viewer.events.theme.connect(
+        self._viewer.events.theme.connect(
             lambda e: self.keyframesListWidget._update_theme(e.value)
         )
 
     def _release_callbacks(self):
         """Release keys"""
 
-        self.animation.viewer.bind_key("Alt-f", None)
-        self.animation.viewer.bind_key("Alt-r", None)
-        self.animation.viewer.bind_key("Alt-d", None)
+        self._viewer.bind_key("Alt-f", None)
+        self._viewer.bind_key("Alt-r", None)
+        self._viewer.bind_key("Alt-d", None)
 
-        self.animation.viewer.bind_key("Alt-a", None)
-        self.animation.viewer.bind_key("Alt-b", None)
+        self._viewer.bind_key("Alt-a", None)
+        self._viewer.bind_key("Alt-b", None)
 
     def _init_frame_widget(self):
         self.frameWidget = FrameWidget(parent=self)
@@ -112,7 +108,7 @@ class AnimationWidget(QWidget):
         self.keyframesListWidget = KeyFramesListWidget(
             self.animation, parent=self
         )
-        self.keyframesListWidget._update_theme(self.viewer.theme)
+        self.keyframesListWidget._update_theme(self._viewer.theme)
         self._layout.addWidget(self.keyframesListWidget)
 
     def _init_save_button(self):

--- a/napari_animation/_tests/conftest.py
+++ b/napari_animation/_tests/conftest.py
@@ -20,7 +20,7 @@ def empty_animation(make_napari_viewer):
 def animation_with_key_frames(empty_animation):
     for i in range(2):
         empty_animation.capture_keyframe()
-        empty_animation.viewer.camera.zoom *= 2
+        empty_animation._viewer.camera.zoom *= 2
     return empty_animation
 
 

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -56,8 +56,8 @@ def test_set_viewer_state(animation_with_key_frames, viewer_state):
     current_state = animation._get_viewer_state()
     animation._set_viewer_state(viewer_state)
 
-    animation_dims_state = animation.viewer.dims.dict()
-    animation_camera_state = animation.viewer.camera.dict()
+    animation_dims_state = animation._viewer.dims.dict()
+    animation_camera_state = animation._viewer.camera.dict()
 
     assert animation_dims_state == current_state["dims"]
     for key in ("center", "angles", "interactive"):
@@ -107,7 +107,7 @@ def test_layer_attribute_capture(layer_state, attribute):
 def test_end_state_reached(image_animation):
     """Check that animation ends in the same state as the final key-frame"""
     image_animation.capture_keyframe()
-    image_animation.viewer.dims.current_step = (28, 0)
+    image_animation._viewer.dims.current_step = (28, 0)
     image_animation.capture_keyframe(steps=2)
     for state in image_animation._state_generator():
         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
 	napari>=0.4.5
 	napari-plugin-engine>=0.1.9
 	numpy
+    pydantic
 	qtpy
 	scipy
 


### PR DESCRIPTION
To adress #18 and #78 ! I switched `Animation` to an `EventedModel` in a very basic way, to take it step by step (I'm not sure I get everything right). 

As I understand we still need `key_frames` to be an `EventedList` so I kept that, but set `allow_mutable` to False for now, to prevent users from just setting it to a `List`, that would then not be evented. I think to take this into account I can make a property setter to convert a List to an EventedList, but I I think all callbacks would need to be reset then .

Curious to hear your opinions/ideas, as I'm stepping in something I don't know well !