### PR TITLE
Add `KeyFrame` object

### DIFF
--- a/napari_animation/__init__.py
+++ b/napari_animation/__init__.py
@@ -1,3 +1,4 @@
 from ._hookimpls import napari_experimental_provide_dock_widget
 from ._qt import AnimationWidget
 from .animation import Animation
+from .key_frame import KeyFrame, ViewerState

--- a/napari_animation/_qt/animationslider_widget.py
+++ b/napari_animation/_qt/animationslider_widget.py
@@ -49,5 +49,5 @@ class AnimationSliderWidget(QSlider):
 
     def _compute_cumulative_frame_count(self):
         """Compute cumulative frame count"""
-        steps = [keyframe["steps"] for keyframe in self.animation.key_frames]
+        steps = [keyframe.steps for keyframe in self.animation.key_frames]
         self.cumulative_frame_count = np.insert(np.cumsum(steps), 0, 0)

--- a/napari_animation/_qt/frame_widget.py
+++ b/napari_animation/_qt/frame_widget.py
@@ -18,7 +18,7 @@ class FrameWidget(QWidget):
 
     def _init_steps(self):
         self.stepsSpinBox = QSpinBox()
-        self.stepsSpinBox.setRange(1, 100000);
+        self.stepsSpinBox.setRange(1, 100000)
         self.stepsSpinBox.setValue(15)
         self._layout.addRow("Steps", self.stepsSpinBox)
 
@@ -31,8 +31,7 @@ class FrameWidget(QWidget):
 
     def get_easing_func(self):
         easing_name = str(self.easeComboBox.currentText())
-        easing_func = Easing[easing_name.upper()]
-        return easing_func
+        return Easing[easing_name.upper()]
 
     def update_from_animation(self):
         """update state of self to reflect animation state at current key frame"""
@@ -41,22 +40,22 @@ class FrameWidget(QWidget):
 
     def _update_steps_spin_box(self):
         """update state of steps spin box to reflect animation state at current key frame"""
-        self.stepsSpinBox.setValue(self.animation.current_key_frame["steps"])
+        self.stepsSpinBox.setValue(self.animation.current_key_frame.steps)
 
     def _update_animation_steps(self, event):
         """update state of 'steps' at current key-frame to reflect GUI state"""
-        self.animation.current_key_frame["steps"] = self.stepsSpinBox.value()
+        self.animation.current_key_frame.steps = self.stepsSpinBox.value()
 
     def _update_ease_combo_box(self):
         """update state of ease combo box to reflect animation state at current key frame"""
-        ease = self.animation.current_key_frame["ease"]
+        ease = self.animation.current_key_frame.ease
         name = _easing_func_to_name(ease)
         index = self.easeComboBox.findText(name, Qt.MatchFixedString)
         self.easeComboBox.setCurrentIndex(index)
 
     def _update_animation_ease(self, event):
         """update state of 'ease' at current key-frame to reflect GUI state"""
-        self.animation.current_key_frame["ease"] = self.get_easing_func()
+        self.animation.current_key_frame.ease = self.get_easing_func()
 
     def _add_callbacks(self):
         """add callbacks to steps and ease widgets"""

--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -96,15 +96,13 @@ class KeyFramesListWidget(QListWidget):
 
     def _icon_from_key_frame(self, key_frame):
         """Generate QIcon from a key frame"""
-        thumbnail = key_frame["thumbnail"]
         thumbnail = QImage(
-            thumbnail,
-            thumbnail.shape[1],
-            thumbnail.shape[0],
+            key_frame.thumbnail,
+            key_frame.thumbnail.shape[1],
+            key_frame.thumbnail.shape[0],
             QImage.Format_RGBA8888,
         )
-        icon = QIcon(QPixmap.fromImage(thumbnail))
-        return icon
+        return QIcon(QPixmap.fromImage(thumbnail))
 
     def _get_key_frame(self, key_frame_idx):
         """Get key frame dict from key frames list at key_frame_idx"""

--- a/napari_animation/_tests/conftest.py
+++ b/napari_animation/_tests/conftest.py
@@ -2,6 +2,7 @@
 discovery at test time.
 https://docs.pytest.org/en/stable/fixture.html
 """
+from napari_animation.key_frame import ViewerState
 import numpy as np
 import pytest
 
@@ -26,7 +27,7 @@ def animation_with_key_frames(empty_animation):
 
 @pytest.fixture
 def viewer_state(empty_animation):
-    return empty_animation._get_viewer_state()
+    return ViewerState.from_viewer(empty_animation.viewer)
 
 
 @pytest.fixture
@@ -38,11 +39,10 @@ def key_frames(animation_with_key_frames):
 def image_animation(make_napari_viewer):
     viewer = make_napari_viewer()
     viewer.add_image(np.random.random((28, 28)))
-    animation = Animation(viewer)
-    return animation
+    return Animation(viewer)
 
 
 @pytest.fixture
-def layer_state(image_animation):
+def layer_state(image_animation: Animation):
     image_animation.capture_keyframe()
-    return image_animation.key_frames[0]["viewer"]["layers"]
+    return image_animation.key_frames[0].viewer_state.layers

--- a/napari_animation/_tests/test_interpolation.py
+++ b/napari_animation/_tests/test_interpolation.py
@@ -2,6 +2,7 @@ import numbers
 
 import numpy as np
 import pytest
+from dataclasses import asdict
 
 from napari_animation.interpolation import (
     interpolate_bool,
@@ -88,8 +89,8 @@ def test_interpolate_log(a, b, fraction):
 @pytest.mark.parametrize("fraction", [0, 0.2, 0.4, 0.6, 0.8, 1])
 def test_interpolate_state(key_frames, fraction):
     """Check that state interpolation works"""
-    initial_state = key_frames[0]["viewer"]
-    final_state = key_frames[1]["viewer"]
+    initial_state = asdict(key_frames[0].viewer_state)
+    final_state = asdict(key_frames[1].viewer_state)
     result = interpolate_state(initial_state, final_state, fraction)
     assert len(result) == len(initial_state)
     if fraction == 0:

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -3,21 +3,25 @@ from pathlib import Path
 
 import imageio
 import numpy as np
-from napari.layers.utils.layer_utils import convert_to_uint8
 from napari.utils.events import EventedList
 from napari.utils.io import imsave
+
 from scipy import ndimage as ndi
 
 from .easing import Easing
 from .interpolation import Interpolation, interpolate_state
+from .key_frame import KeyFrame, ViewerState
+from dataclasses import asdict
 
 
 class Animation:
     """Make animations using the napari viewer.
+
     Parameters
     ----------
     viewer : napari.Viewer
         napari viewer.
+
     Attributes
     ----------
     key_frames : list of dict
@@ -31,17 +35,18 @@ class Animation:
     def __init__(self, viewer):
         self.viewer = viewer
 
-        self.key_frames = EventedList()
-        self.frame = -1
+        self.key_frames: EventedList[KeyFrame] = EventedList()
+        self.frame: int = -1
         self.state_interpolation_map = {
             "camera.angles": Interpolation.SLERP,
             "camera.zoom": Interpolation.LOG,
         }
 
     def capture_keyframe(
-        self, steps=15, ease=Easing.LINEAR, insert=True, frame=None
+        self, steps=15, ease=Easing.LINEAR, insert=True, frame: int = None
     ):
         """Record current key-frame
+
         Parameters
         ----------
         steps : int
@@ -59,12 +64,7 @@ class Animation:
         if frame is not None:
             self.frame = frame
 
-        new_state = {
-            "viewer": self._get_viewer_state(),
-            "thumbnail": self._generate_thumbnail(),
-            "steps": steps,
-            "ease": ease,
-        }
+        new_state = KeyFrame.from_viewer(self.viewer, steps=steps, ease=ease)
 
         if insert or self.frame == -1:
             current_frame = self.frame
@@ -78,7 +78,7 @@ class Animation:
     def n_frames(self):
         """The total frame count of the animation"""
         if len(self.key_frames) >= 2:
-            return np.sum([f["steps"] for f in self.key_frames[1:]]) + 1
+            return np.sum([f.steps for f in self.key_frames[1:]]) + 1
         else:
             return 0
 
@@ -91,50 +91,24 @@ class Animation:
         """
         self.frame = frame
         if len(self.key_frames) > 0 and self.frame > -1:
-            self._set_viewer_state(self.key_frames[frame]["viewer"])
+            self._set_viewer_state(self.key_frames[frame].viewer_state)
 
     def set_to_current_keyframe(self):
         """Set the viewer to the current key-frame"""
-        self._set_viewer_state(self.key_frames[self.frame]["viewer"])
+        self._set_viewer_state(self.key_frames[self.frame].viewer_state)
 
-    def _get_viewer_state(self):
-        """Capture current viewer state
-        Returns
-        -------
-        new_state : dict
-            Description of viewer state.
-        """
-
-        new_state = {
-            "camera": self.viewer.camera.dict(),
-            "dims": self.viewer.dims.dict(),
-            "layers": self._get_layer_state(),
-        }
-
-        return new_state
-
-    def _set_viewer_state(self, state):
+    def _set_viewer_state(self, state: ViewerState):
         """Sets the current viewer state
         Parameters
         ----------
         state : dict
             Description of viewer state.
         """
-        self.viewer.camera.update(state["camera"])
-        self.viewer.dims.update(state["dims"])
-        self._set_layer_state(state["layers"])
+        self.viewer.camera.update(state.camera)
+        self.viewer.dims.update(state.dims)
+        self._set_layer_state(state.layers)
 
-    def _get_layer_state(self):
-        """Store layer state in a dict of dicts {layer.name: state}"""
-        layer_state = {
-            layer.name: layer._get_base_state() for layer in self.viewer.layers
-        }
-        # remove metadata from layer_state dicts
-        for state in layer_state.values():
-            state.pop("metadata")
-        return layer_state
-
-    def _set_layer_state(self, layer_state):
+    def _set_layer_state(self, layer_state: dict):
         for layer_name, layer_state in layer_state.items():
             layer = self.viewer.layers[layer_name]
             for key, value in layer_state.items():
@@ -150,22 +124,22 @@ class Animation:
             self.key_frames, self.key_frames[1:]
         ):
             # capture necessary info for interpolation
-            initial_state = current_frame["viewer"]
-            final_state = next_frame["viewer"]
-            interpolation_steps = next_frame["steps"]
-            ease = next_frame["ease"]
+            initial_state = current_frame.viewer_state
+            final_state = next_frame.viewer_state
+            interpolation_steps = next_frame.steps
+            ease = next_frame.ease
 
             # generate intermediate states between key-frames
             for interp in range(interpolation_steps):
                 fraction = interp / interpolation_steps
                 fraction = ease(fraction)
                 state = interpolate_state(
-                    initial_state,
-                    final_state,
+                    asdict(initial_state),
+                    asdict(final_state),
                     fraction,
                     self.state_interpolation_map,
                 )
-                yield state
+                yield ViewerState(**state)
 
         # be sure to include the final state
         yield final_state
@@ -182,37 +156,6 @@ class Animation:
             self._set_viewer_state(state)
             frame = self.viewer.screenshot(canvas_only=canvas_only)
             yield frame
-
-    def _generate_thumbnail(self):
-        """generate a thumbnail from viewer"""
-        screenshot = self.viewer.screenshot(canvas_only=True)
-        thumbnail = self._coerce_image_into_thumbnail_shape(screenshot)
-        return thumbnail
-
-    def _coerce_image_into_thumbnail_shape(self, image):
-        """Resizes an image to self._thumbnail_shape with padding"""
-        scale_factor = np.min(np.divide(self._thumbnail_shape, image.shape))
-        intermediate_image = ndi.zoom(image, (scale_factor, scale_factor, 1))
-
-        padding_needed = np.subtract(
-            self._thumbnail_shape, intermediate_image.shape
-        )
-        pad_amounts = [(p // 2, (p + 1) // 2) for p in padding_needed]
-        thumbnail = np.pad(intermediate_image, pad_amounts, mode="constant")
-        thumbnail = convert_to_uint8(thumbnail)
-
-        # blend thumbnail with opaque black background
-        background = np.zeros(self._thumbnail_shape, dtype=np.uint8)
-        background[..., 3] = 255
-
-        f_dest = thumbnail[..., 3][..., None] / 255
-        f_source = 1 - f_dest
-        thumbnail = thumbnail * f_dest + background * f_source
-        return thumbnail.astype(np.uint8)
-
-    @property
-    def _thumbnail_shape(self):
-        return (32, 32, 4)
 
     @property
     def current_key_frame(self):

--- a/napari_animation/key_frame.py
+++ b/napari_animation/key_frame.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from .easing import Easing
+from .utils import make_thumbnail
+
+if TYPE_CHECKING:
+    from napari import Viewer
+
+
+@dataclass
+class ViewerState:
+    """The state of the viewer camera, dims, and layers.
+
+    Parameters
+    ----------
+    camera : dict
+        The state of the `napari.components.Camera` in the viewer.
+    dims : dict
+        The state of the `napari.components.Dims` in the viewer.
+    layers : dict
+        A map of layer.name -> _base_state for each layer in the viewer
+        (excluding metadata).
+    """
+
+    camera: dict
+    dims: dict
+    layers: dict
+
+    @classmethod
+    def from_viewer(cls, viewer: Viewer):
+        """Create a ViewerState from a viewer instance."""
+        layers = {
+            layer.name: layer._get_base_state() for layer in viewer.layers
+        }
+        for d in layers.values():
+            d.pop("metadata")
+        return cls(
+            camera=viewer.camera.dict(), dims=viewer.dims.dict(), layers=layers
+        )
+
+
+@dataclass
+class KeyFrame:
+    """A single keyframe in the animation.
+
+    Parameters
+    ----------
+    viewer_state : ViewerState
+        The state of the viewer at this keyframe.
+    thumbnail : np.ndarray
+        A thumbnail representing this keyframe.
+    steps : int
+        Number of interpolation steps between last keyframe and captured one.
+    ease : callable, optional
+        If provided this method should make from `[0, 1]` to `[0, 1]` and will
+        be used as an easing function for the transition between the last state
+        and captured one.
+    """
+
+    viewer_state: ViewerState
+    thumbnail: np.ndarray
+    steps: int = 15
+    ease: Easing = Easing.LINEAR
+
+    @classmethod
+    def from_viewer(cls, viewer: Viewer, steps=15, ease=Easing.LINEAR):
+        """Create a KeyFrame from a viewer instance."""
+        return cls(
+            viewer_state=ViewerState.from_viewer(viewer),
+            thumbnail=make_thumbnail(viewer.screenshot(canvas_only=True)),
+            steps=steps,
+            ease=ease,
+        )

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -125,3 +125,26 @@ def quaternion2euler(quaternion, degrees=False):
         return tuple(np.degrees(angles))
     else:
         return angles
+
+
+def make_thumbnail(image: np.ndarray, shape=(32, 32, 4)) -> np.ndarray:
+    """Resizes an image to `shape` with padding"""
+    from napari.layers.utils.layer_utils import convert_to_uint8
+    from scipy import ndimage as ndi
+
+    scale_factor = np.min(np.divide(shape, image.shape))
+    intermediate_image = ndi.zoom(image, (scale_factor, scale_factor, 1))
+
+    padding_needed = np.subtract(shape, intermediate_image.shape)
+    pad_amounts = [(p // 2, (p + 1) // 2) for p in padding_needed]
+    thumbnail = np.pad(intermediate_image, pad_amounts, mode="constant")
+    thumbnail = convert_to_uint8(thumbnail)
+
+    # blend thumbnail with opaque black background
+    background = np.zeros(shape, dtype=np.uint8)
+    background[..., 3] = 255
+
+    f_dest = thumbnail[..., 3][..., None] / 255
+    f_source = 1 - f_dest
+    thumbnail = thumbnail * f_dest + background * f_source
+    return thumbnail.astype(np.uint8)


### PR DESCRIPTION
Haven't been around for the earlier conversations ... so not sure how you'll feel about this, but I was starting to look into updating the `KeyFramesListWidget` to take advantage of some of the new `QListWidget` stuff in napari (since you're already using the `EventedList`) ... however, capturing a keyframe as a pure dict presents some challenges (particularly when it comes a set-based selection model), since dicts are not hashable.

Also, as a relative newcomer to the codebase, I found myself wondering "what exactly _is_ this mysterious keyframe object?"  What are the possible, keys, etc...

So this PR introduces a `KeyFrame` and `ViewerState` dataclass, and pulls some of the methods off of `Animation` that are just there to create a new KeyFrame from the current viewer and adds them as `KeyFrame.from_viewer` and `ViewerState.from_viewer`.

if you were liking the "keyframe-as-pure-dict" model, feel free to reject this... but something like this will be necessary if you want to use the `SelectableEventedList` and associated listviews.