### PR TITLE
Switch key_frames to a SelectableEventedList

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -158,8 +158,10 @@ class AnimationWidget(QWidget):
     def _delete_keyframe_callback(self, event=None):
         """Delete current key-frame"""
         if len(self.animation.key_frames) > 0:
-            self.animation.key_frames.pop(self.animation.frame)
+            self.animation.key_frames.pop(self.animation.current_key_frame)
+            print(1)
         if len(self.animation.key_frames) == 0:
+            print(2)
             self.keyframesListControlWidget.deleteButton.setEnabled(False)
             self.keyframesListWidget.setEnabled(False)
             self.frameWidget.setEnabled(False)
@@ -168,16 +170,22 @@ class AnimationWidget(QWidget):
     def _key_adv_frame(self, event=None):
         """Go forwards in key-frame list"""
 
-        new_frame = (self.animation.frame + 1) % len(self.animation.key_frames)
-        self.animation.set_to_keyframe(new_frame)
-        self.keyframesListWidget.setCurrentRow(new_frame)
+        new_frame = (self.animation.current_key_frame + 1) % len(
+            self.animation.key_frames
+        )
+        self.animation.current_key_frame = new_frame
+        # self.animation.set_to_keyframe(new_frame)
+        # self.keyframesListWidget.setCurrentRow(new_frame)
 
     def _key_back_frame(self, event=None):
         """Go backwards in key-frame list"""
 
-        new_frame = (self.animation.frame - 1) % len(self.animation.key_frames)
-        self.animation.set_to_keyframe(new_frame)
-        self.keyframesListWidget.setCurrentRow(new_frame)
+        new_frame = (self.animation.current_key_frame - 1) % len(
+            self.animation.key_frames
+        )
+        self.animation.current_key_frame = new_frame
+        # self.animation.set_to_keyframe(new_frame)
+        # self.keyframesListWidget.setCurrentRow(new_frame)
 
     def _save_callback(self, event=None):
 
@@ -214,8 +222,8 @@ class AnimationWidget(QWidget):
         ).argmax()
         new_key_frame -= 1  # to get the previous key frame
         new_key_frame = int(new_key_frame)  # to enable slicing a list with it
-        self.keyframesListWidget.setCurrentRowBlockingSignals(new_key_frame)
-        self.animation.frame = new_key_frame
+        # self.keyframesListWidget.setCurrentRowBlockingSignals(new_key_frame)
+        self.animation.current_key_frame = new_key_frame
 
     def close(self):
         self._release_callbacks()

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -159,9 +159,8 @@ class AnimationWidget(QWidget):
         """Delete current key-frame"""
         if len(self.animation.key_frames) > 0:
             self.animation.key_frames.pop(self.animation.current_key_frame)
-            print(1)
+
         if len(self.animation.key_frames) == 0:
-            print(2)
             self.keyframesListControlWidget.deleteButton.setEnabled(False)
             self.keyframesListWidget.setEnabled(False)
             self.frameWidget.setEnabled(False)
@@ -169,13 +168,10 @@ class AnimationWidget(QWidget):
 
     def _key_adv_frame(self, event=None):
         """Go forwards in key-frame list"""
-
         new_frame = (self.animation.current_key_frame + 1) % len(
             self.animation.key_frames
         )
         self.animation.current_key_frame = new_frame
-        # self.animation.set_to_keyframe(new_frame)
-        # self.keyframesListWidget.setCurrentRow(new_frame)
 
     def _key_back_frame(self, event=None):
         """Go backwards in key-frame list"""
@@ -184,8 +180,6 @@ class AnimationWidget(QWidget):
             self.animation.key_frames
         )
         self.animation.current_key_frame = new_frame
-        # self.animation.set_to_keyframe(new_frame)
-        # self.keyframesListWidget.setCurrentRow(new_frame)
 
     def _save_callback(self, event=None):
 
@@ -212,6 +206,7 @@ class AnimationWidget(QWidget):
         """Scroll through interpolated states. Computes states if key-frames changed"""
         self.animationsliderWidget.synchronise()
         new_frame = self.animationsliderWidget.value()
+
         self.animation._set_viewer_state(
             self.animationsliderWidget.interpol_states[new_frame]
         )
@@ -222,8 +217,18 @@ class AnimationWidget(QWidget):
         ).argmax()
         new_key_frame -= 1  # to get the previous key frame
         new_key_frame = int(new_key_frame)  # to enable slicing a list with it
-        # self.keyframesListWidget.setCurrentRowBlockingSignals(new_key_frame)
+
+        # block selection callbacks during the setting
+        self.animation.key_frames.selection.events._current.block()
+        self.keyframesListWidget.blockSignals(True)
+
+        self.keyframesListWidget.setCurrentRowBlockingSignals(new_key_frame)
         self.animation.current_key_frame = new_key_frame
+        self._update_frame_widget_from_animation()
+
+        # unblock callbacks
+        self.animation.key_frames.selection.events._current.unblock()
+        self.keyframesListWidget.blockSignals(False)
 
     def close(self):
         self._release_callbacks()

--- a/napari_animation/_qt/frame_widget.py
+++ b/napari_animation/_qt/frame_widget.py
@@ -40,22 +40,30 @@ class FrameWidget(QWidget):
 
     def _update_steps_spin_box(self):
         """update state of steps spin box to reflect animation state at current key frame"""
-        self.stepsSpinBox.setValue(self.animation.current_key_frame.steps)
+        key_frame_idx = self.animation.current_key_frame
+        self.stepsSpinBox.setValue(
+            self.animation.key_frames[key_frame_idx].steps
+        )
 
     def _update_animation_steps(self, event):
         """update state of 'steps' at current key-frame to reflect GUI state"""
-        self.animation.current_key_frame.steps = self.stepsSpinBox.value()
+        key_frame_idx = self.animation.current_key_frame
+        self.animation.key_frames[
+            key_frame_idx
+        ].steps = self.stepsSpinBox.value()
 
     def _update_ease_combo_box(self):
         """update state of ease combo box to reflect animation state at current key frame"""
-        ease = self.animation.current_key_frame.ease
+        key_frame_idx = self.animation.current_key_frame
+        ease = self.animation.key_frames[key_frame_idx].ease
         name = _easing_func_to_name(ease)
         index = self.easeComboBox.findText(name, Qt.MatchFixedString)
         self.easeComboBox.setCurrentIndex(index)
 
     def _update_animation_ease(self, event):
         """update state of 'ease' at current key-frame to reflect GUI state"""
-        self.animation.current_key_frame.ease = self.get_easing_func()
+        key_frame_idx = self.animation.current_key_frame
+        self.animation.key_frames[key_frame_idx].ease = self.get_easing_func()
 
     def _add_callbacks(self):
         """add callbacks to steps and ease widgets"""

--- a/napari_animation/_qt/keyframeslist_widget.py
+++ b/napari_animation/_qt/keyframeslist_widget.py
@@ -37,6 +37,9 @@ class KeyFramesListWidget(QListWidget):
         self.animation.key_frames.events.reordered.connect(
             self._reorder_frontend
         )
+        self.animation.key_frames.selection.events._current.connect(
+            self._update_selected_frame
+        )
 
     def dropEvent(self, event):
         """update backend state on 'drop' of frame in key frames list"""
@@ -46,14 +49,15 @@ class KeyFramesListWidget(QListWidget):
 
     def _selection_callback(self):
         self._update_frame_number()
-        if self.animation.frame != -1:
-            self.animation.set_to_current_keyframe()
+        if self.animation.current_key_frame:
+            # self.animation.set_to_current_keyframe()
             self.parentWidget()._update_frame_widget_from_animation()
 
     def _add(self, event):
         """Generate QListWidgetItem for current keyframe, store its unique id and add it to self"""
         key_frame, idx = event.value, event.index
         item = self._generate_list_item(key_frame)
+        # self.insertItemBlockingSignals(idx, item)
         self.insertItem(idx, item)
         self._add_mappings(key_frame, item)
         self._frame_count += 1
@@ -86,7 +90,11 @@ class KeyFramesListWidget(QListWidget):
 
     def _update_frame_number(self):
         """update the frame number of self.animation based on selected item in frontend"""
-        self.animation.frame = self._get_selected_index()
+        self.animation.current_key_frame = self._get_selected_index()
+
+    def _update_selected_frame(self, event):
+        key_frame_idx = self.animation.current_key_frame
+        self.setCurrentRowBlockingSignals(key_frame_idx)
 
     def _generate_list_item(self, key_frame):
         """Generate a QListWidgetItem from a key-frame"""
@@ -104,9 +112,9 @@ class KeyFramesListWidget(QListWidget):
         )
         return QIcon(QPixmap.fromImage(thumbnail))
 
-    def _get_key_frame(self, key_frame_idx):
-        """Get key frame dict from key frames list at key_frame_idx"""
-        return self.animation.key_frames[key_frame_idx]
+    # def _get_key_frame(self, key_frame_idx):
+    #     """Get key frame dict from key frames list at key_frame_idx"""
+    #     return self.animation.key_frames[key_frame_idx]
 
     def _get_selected_index(self):
         """Get index of currently selected row"""

--- a/napari_animation/_tests/conftest.py
+++ b/napari_animation/_tests/conftest.py
@@ -2,11 +2,11 @@
 discovery at test time.
 https://docs.pytest.org/en/stable/fixture.html
 """
-from napari_animation.key_frame import ViewerState
 import numpy as np
 import pytest
 
 from napari_animation import Animation
+from napari_animation.key_frame import ViewerState
 
 
 @pytest.fixture

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -39,7 +39,7 @@ def test_set_to_key_frame(animation_with_key_frames):
     animation = animation_with_key_frames
     for i in range(2):
         animation.set_to_keyframe(i)
-        assert animation.frame == i
+        assert animation.current_key_frame == i
 
 
 def test_get_viewer_state(empty_animation):

--- a/napari_animation/_tests/test_interpolation.py
+++ b/napari_animation/_tests/test_interpolation.py
@@ -1,8 +1,8 @@
 import numbers
+from dataclasses import asdict
 
 import numpy as np
 import pytest
-from dataclasses import asdict
 
 from napari_animation.interpolation import (
     interpolate_bool,

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -39,7 +39,7 @@ class Animation:
             KeyFrame
         ] = SelectableEventedList(basetype=KeyFrame)
         self.key_frames.selection.events.active.connect(
-            lambda e: self._set_viewer_state(e.value)
+            lambda e: self._set_viewer_state(e.value.viewer_state)
         )
 
         self.state_interpolation_map = {
@@ -68,14 +68,18 @@ class Animation:
             active frame.
         """
         if position is None:
-            position = self.key_frames.index(self.key_frames.selection.active)
+            if self.key_frames:
+                position = self.current_key_frame
+            else:
+                position = -1
+                insert = True
 
         new_frame = KeyFrame.from_viewer(self.viewer, steps=steps, ease=ease)
 
         if insert:
-            self.key_frames.insert(position + 1, new_frame)
+            self.key_frames.insert(position + 1, new_frame)        
         else:
-            self.key_frames[self.frame] = new_frame
+            self.key_frames[position] = new_frame
 
     @property
     def n_frames(self):
@@ -161,7 +165,7 @@ class Animation:
 
     @property
     def current_key_frame(self):
-        return self.key_frames[self.frame]
+        return self.key_frames.index(self.key_frames.selection._current)
 
     def animate(
         self,

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -38,7 +38,9 @@ class Animation:
         self.key_frames: SelectableEventedList[
             KeyFrame
         ] = SelectableEventedList(basetype=KeyFrame)
-        self.key_frames.selection.events.active.connect(self._active_callback)
+        self.key_frames.selection.events._current.connect(
+            self._current_callback
+        )
 
         self.state_interpolation_map = {
             "camera.angles": Interpolation.SLERP,
@@ -283,6 +285,6 @@ class Animation:
         if not save_as_folder:
             writer.close()
 
-    def _active_callback(self, event):
+    def _current_callback(self, event):
         if event.value:
             self._set_viewer_state(event.value.viewer_state)

--- a/napari_animation/key_frame.py
+++ b/napari_animation/key_frame.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from napari import Viewer
 
 
-@dataclass
+@dataclass(frozen=True)
 class ViewerState:
     """The state of the viewer camera, dims, and layers.
 
@@ -44,7 +44,7 @@ class ViewerState:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class KeyFrame:
     """A single keyframe in the animation.
 
@@ -76,3 +76,6 @@ class KeyFrame:
             steps=steps,
             ease=ease,
         )
+
+    def __hash__(self) -> int:
+        return id(self)

--- a/napari_animation/key_frame.py
+++ b/napari_animation/key_frame.py
@@ -44,6 +44,17 @@ class ViewerState:
         )
 
 
+    def __eq__(self, other):
+        if isinstance(other, ViewerState):
+            return (
+                self.camera == other.camera and
+                self.dims == other.dims and
+                self.layers == other.layers
+            )
+        else:
+            return False
+
+
 @dataclass(frozen=True)
 class KeyFrame:
     """A single keyframe in the animation.
@@ -79,3 +90,17 @@ class KeyFrame:
 
     def __hash__(self) -> int:
         return id(self)
+
+    def __eq__(self, other):
+        if isinstance(other, KeyFrame):
+            return (
+                self.__hash__() == other.__hash__() and
+                self.viewer_state == other.viewer_state and
+                (self.thumbnail == other.thumbnail).all() and
+                self.steps == other.steps and
+                self.ease == other.ease
+            )
+        else:
+            return False
+
+            

--- a/napari_animation/key_frame.py
+++ b/napari_animation/key_frame.py
@@ -43,13 +43,12 @@ class ViewerState:
             camera=viewer.camera.dict(), dims=viewer.dims.dict(), layers=layers
         )
 
-
     def __eq__(self, other):
         if isinstance(other, ViewerState):
             return (
-                self.camera == other.camera and
-                self.dims == other.dims and
-                self.layers == other.layers
+                self.camera == other.camera
+                and self.dims == other.dims
+                and self.layers == other.layers
             )
         else:
             return False
@@ -94,13 +93,11 @@ class KeyFrame:
     def __eq__(self, other):
         if isinstance(other, KeyFrame):
             return (
-                self.__hash__() == other.__hash__() and
-                self.viewer_state == other.viewer_state and
-                (self.thumbnail == other.thumbnail).all() and
-                self.steps == other.steps and
-                self.ease == other.ease
+                self.__hash__() == other.__hash__()
+                and self.viewer_state == other.viewer_state
+                and (self.thumbnail == other.thumbnail).all()
+                and self.steps == other.steps
+                and self.ease == other.ease
             )
         else:
             return False
-
-            

--- a/napari_animation/key_frame.py
+++ b/napari_animation/key_frame.py
@@ -54,7 +54,8 @@ class ViewerState:
             return False
 
 
-@dataclass(frozen=True)
+# @dataclass(frozen=True)
+@dataclass  # we want to modify steps and ease from the widget for instance
 class KeyFrame:
     """A single keyframe in the animation.
 


### PR DESCRIPTION
This PR is a follow up on the #87 ! Starting from @tlambert03 suggestions, I'm trying to switch `Animation.key_frames` to a `SelectableEventedList`, and change the widgets accordingly.

This PR is functional and pass tests, but there is still a lot to discuss. Main modifications are :

- Switched key_frames to a `SelectableEventedList`
- Decided to mainly use the `key_frames.selection._current` reference (as opposed to the `active` one) to manage selected key frame, and linked it to `Animation.current_key_frame`. Still I defined an `active_key_frame` attribute in case.
- I unfroze KeyFrame, as we want to modify some of its contents (from the GUI via the steps widget for instance).
- Added an `__eq__` to `KeyFrame` as value equality is checked during some `SelectableEventedList` methods. Also added one on `ViewerState`.
- I modified as little as possible the KeyFramesListWidget as suggested in #87 
- Tried to manage callbacks there, so it's functional but I guess it's still way unoptimal.
- I added an update of displayed steps and ease widgets when the slider's moving.

I'm happy to start a discussion on this ! 😅 