### PR TITLE
remove unnecessary duplication of state interpolation

### DIFF
--- a/napari_animation/_tests/test_interpolation.py
+++ b/napari_animation/_tests/test_interpolation.py
@@ -1,4 +1,3 @@
-import numbers
 from dataclasses import asdict
 
 import numpy as np
@@ -9,38 +8,11 @@ from napari_animation.interpolation import (
     interpolate_log,
     interpolate_num,
     interpolate_seq,
-    interpolate_state,
 )
 
-from ..utils import keys_to_list, nested_get
-
+from ..utils import nested_assert_close
 
 # Define some functions used for testing
-def nested_assert_close(a, b):
-    """ Assert close on nested dicts."""
-    a_keys = [key for key in keys_to_list(a)]
-    b_keys = [key for key in keys_to_list(b)]
-
-    assert a_keys == b_keys
-
-    for key in a_keys:
-        a_1 = nested_get(a, key)
-        b_1 = nested_get(b, key)
-
-        nested_seq_assert_close(a_1, b_1)
-
-
-def nested_seq_assert_close(a, b):
-    """ Assert close to scalar or potentially nested qequences of numeric types and others."""
-    if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
-        assert type(a) == type(b)
-        for a_v, b_v in zip(a, b):
-            nested_seq_assert_close(a_v, b_v)
-    else:
-        if isinstance(a, numbers.Number):
-            np.testing.assert_allclose(a, b)
-        else:
-            assert a == b
 
 
 # Actual tests
@@ -87,18 +59,20 @@ def test_interpolate_log(a, b, fraction):
 
 
 @pytest.mark.parametrize("fraction", [0, 0.2, 0.4, 0.6, 0.8, 1])
-def test_interpolate_state(key_frames, fraction):
+def test_interpolate_state(frame_sequence, fraction):
     """Check that state interpolation works"""
-    initial_state = asdict(key_frames[0].viewer_state)
-    final_state = asdict(key_frames[1].viewer_state)
-    result = interpolate_state(initial_state, final_state, fraction)
-    assert len(result) == len(initial_state)
+    initial_state = frame_sequence[0]
+    final_state = frame_sequence[-1]
+    result = frame_sequence._interpolate_state(
+        initial_state, final_state, fraction
+    )
+    assert len(asdict(result)) == len(asdict(initial_state))
     if fraction == 0:
         # assert result == initial_state
-        nested_assert_close(result, initial_state)
+        nested_assert_close(asdict(result), asdict(initial_state))
     elif fraction == 1:
         # assert result == final_state
-        nested_assert_close(result, final_state)
+        nested_assert_close(asdict(result), asdict(final_state))
 
     # else:
     # should find something else to test

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -108,9 +108,9 @@ class FrameSequence(Sequence[ViewerState]):
 
         Parameters
         ----------
-        from_state : dict
+        from_state : ViewerState
             Description of initial viewer state.
-        to_state : dict
+        to_state : ViewerState
             Description of final viewer state.
         fraction : float
             Interpolation fraction, must be between `0` and `1`.

--- a/napari_animation/interpolation.py
+++ b/napari_animation/interpolation.py
@@ -6,8 +6,6 @@ from typing import Dict
 import numpy as np
 from scipy.spatial.transform import Rotation as R
 
-from .utils import keys_to_list, nested_get, nested_set
-
 
 def default(a, b, fraction):
     """Default interpolation for the corresponding type;
@@ -165,46 +163,3 @@ class Interpolation(Enum):
 
 
 InterpolationMap = Dict[str, Interpolation]
-
-
-def interpolate_state(
-    initial_state, final_state, fraction, state_interpolation_map={}
-):
-    """Interpolate a state between two states
-
-    Parameters
-    ----------
-    initial_state : dict
-        Description of initial viewer state.
-    final_state : dict
-        Description of final viewer state.
-    fraction : float
-        Interpolation fraction, must be between `0` and `1`.
-        A value of `0` will return the initial state. A
-        value of `1` will return the final state.
-    state_interpolation_map : dict
-        Dictionary relating state attributes to interpolation functions.
-
-    Returns
-    -------
-    state : dict
-        Description of viewer state.
-    """
-
-    state = dict()
-    separator = "."
-
-    for keys in keys_to_list(initial_state):
-        v0 = nested_get(initial_state, keys)
-        v1 = nested_get(final_state, keys)
-
-        property_string = separator.join(keys)
-
-        if property_string in state_interpolation_map.keys():
-            interpolation_func = state_interpolation_map[property_string]
-        else:
-            interpolation_func = Interpolation.DEFAULT
-
-        nested_set(state, keys, interpolation_func(v0, v1, fraction))
-
-    return state

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -1,4 +1,5 @@
 import itertools
+import numbers
 
 import numpy as np
 
@@ -93,3 +94,29 @@ def pairwise(iterable):
     a, b = itertools.tee(iterable)
     next(b, None)
     return zip(a, b)
+
+
+def nested_assert_close(a, b):
+    """ Assert close on nested dicts."""
+    a_keys = [key for key in keys_to_list(a)]
+    b_keys = [key for key in keys_to_list(b)]
+
+    assert a_keys == b_keys
+
+    for key in a_keys:
+        a_1 = nested_get(a, key)
+        b_1 = nested_get(b, key)
+
+        nested_seq_assert_close(a_1, b_1)
+
+
+def nested_seq_assert_close(a, b):
+    """Assert close to scalar or potentially nested qequences of numeric types and others."""
+    if isinstance(a, (list, tuple)) or isinstance(b, (list, tuple)):
+        for a_v, b_v in zip(a, b):
+            nested_seq_assert_close(a_v, b_v)
+    else:
+        if isinstance(a, numbers.Number):
+            np.testing.assert_allclose(a, b)
+        else:
+            assert a == b


### PR DESCRIPTION
state interpolation code was duplicated - removed and fixed test to account for the change

took the opportunity to move some testing utilities into `util`, they could also be moved to `utils.testing` if people prefer

A PR will follow based on this fixing the messy asdict stuff

@Fifourche 