### PR TITLE
Make state interpolation work on ViewerState objects

### DIFF
--- a/napari_animation/_tests/test_frame_sequence.py
+++ b/napari_animation/_tests/test_frame_sequence.py
@@ -5,6 +5,7 @@ import pytest
 
 from napari_animation.frame_sequence import FrameSequence
 from napari_animation.key_frame import ViewerState
+from napari_animation.utils import nested_assert_close
 
 
 def test_frame_seq(frame_sequence: FrameSequence):
@@ -65,3 +66,22 @@ def test_iterframes(animation_with_key_frames, frame_sequence: FrameSequence):
         assert i.dtype == np.uint8
         if n > 4:
             break
+
+
+@pytest.mark.parametrize("fraction", [0, 0.2, 0.4, 0.6, 0.8, 1])
+def test_interpolate_state(frame_sequence: FrameSequence, fraction):
+    """Check that state interpolation works"""
+    initial_state = frame_sequence[0]
+    final_state = frame_sequence[-1]
+    result = frame_sequence._interpolate_state(
+        initial_state, final_state, fraction
+    )
+    if fraction == 0:
+        # assert result == initial_state
+        nested_assert_close(result, initial_state)
+    elif fraction == 1:
+        # assert result == final_state
+        nested_assert_close(result, final_state)
+
+    # else:
+    # should find something else to test

--- a/napari_animation/_tests/test_interpolation.py
+++ b/napari_animation/_tests/test_interpolation.py
@@ -1,4 +1,3 @@
-import numbers
 from dataclasses import asdict
 
 import numpy as np
@@ -9,38 +8,11 @@ from napari_animation.interpolation import (
     interpolate_log,
     interpolate_num,
     interpolate_seq,
-    interpolate_state,
 )
 
-from ..utils import keys_to_list, nested_get
-
+from ..utils import nested_assert_close
 
 # Define some functions used for testing
-def nested_assert_close(a, b):
-    """ Assert close on nested dicts."""
-    a_keys = [key for key in keys_to_list(a)]
-    b_keys = [key for key in keys_to_list(b)]
-
-    assert a_keys == b_keys
-
-    for key in a_keys:
-        a_1 = nested_get(a, key)
-        b_1 = nested_get(b, key)
-
-        nested_seq_assert_close(a_1, b_1)
-
-
-def nested_seq_assert_close(a, b):
-    """ Assert close to scalar or potentially nested qequences of numeric types and others."""
-    if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
-        assert type(a) == type(b)
-        for a_v, b_v in zip(a, b):
-            nested_seq_assert_close(a_v, b_v)
-    else:
-        if isinstance(a, numbers.Number):
-            np.testing.assert_allclose(a, b)
-        else:
-            assert a == b
 
 
 # Actual tests
@@ -87,18 +59,20 @@ def test_interpolate_log(a, b, fraction):
 
 
 @pytest.mark.parametrize("fraction", [0, 0.2, 0.4, 0.6, 0.8, 1])
-def test_interpolate_state(key_frames, fraction):
+def test_interpolate_state(frame_sequence, fraction):
     """Check that state interpolation works"""
-    initial_state = asdict(key_frames[0].viewer_state)
-    final_state = asdict(key_frames[1].viewer_state)
-    result = interpolate_state(initial_state, final_state, fraction)
-    assert len(result) == len(initial_state)
+    initial_state = frame_sequence[0]
+    final_state = frame_sequence[-1]
+    result = frame_sequence._interpolate_state(
+        initial_state, final_state, fraction
+    )
+    assert len(asdict(result)) == len(asdict(initial_state))
     if fraction == 0:
         # assert result == initial_state
-        nested_assert_close(result, initial_state)
+        nested_assert_close(asdict(result), asdict(initial_state))
     elif fraction == 1:
         # assert result == final_state
-        nested_assert_close(result, final_state)
+        nested_assert_close(asdict(result), asdict(final_state))
 
     # else:
     # should find something else to test

--- a/napari_animation/_tests/test_interpolation.py
+++ b/napari_animation/_tests/test_interpolation.py
@@ -1,5 +1,3 @@
-from dataclasses import asdict
-
 import numpy as np
 import pytest
 
@@ -9,8 +7,6 @@ from napari_animation.interpolation import (
     interpolate_num,
     interpolate_seq,
 )
-
-from ..utils import nested_assert_close
 
 # Define some functions used for testing
 
@@ -56,23 +52,3 @@ def test_interpolate_log(a, b, fraction):
     """Check that log interpolation produces valid output"""
     result = interpolate_log(a, b, fraction)
     assert result == np.power(10, fraction)
-
-
-@pytest.mark.parametrize("fraction", [0, 0.2, 0.4, 0.6, 0.8, 1])
-def test_interpolate_state(frame_sequence, fraction):
-    """Check that state interpolation works"""
-    initial_state = frame_sequence[0]
-    final_state = frame_sequence[-1]
-    result = frame_sequence._interpolate_state(
-        initial_state, final_state, fraction
-    )
-    assert len(asdict(result)) == len(asdict(initial_state))
-    if fraction == 0:
-        # assert result == initial_state
-        nested_assert_close(asdict(result), asdict(initial_state))
-    elif fraction == 1:
-        # assert result == final_state
-        nested_assert_close(asdict(result), asdict(final_state))
-
-    # else:
-    # should find something else to test

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -108,9 +108,9 @@ class FrameSequence(Sequence[ViewerState]):
 
         Parameters
         ----------
-        from_state : dict
+        from_state : ViewerState
             Description of initial viewer state.
-        to_state : dict
+        to_state : ViewerState
             Description of final viewer state.
         fraction : float
             Interpolation fraction, must be between `0` and `1`.

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 from typing import TYPE_CHECKING, Dict, Iterator, Optional, Sequence, Tuple
 
 import numpy as np
@@ -130,9 +129,6 @@ class FrameSequence(Sequence[ViewerState]):
 
         state = {}
         sep = "."
-
-        from_state = asdict(from_state)
-        to_state = asdict(to_state)
 
         for keys in keys_to_list(from_state):
             v0 = nested_get(from_state, keys)

--- a/napari_animation/interpolation.py
+++ b/napari_animation/interpolation.py
@@ -6,8 +6,6 @@ from typing import Dict
 import numpy as np
 from scipy.spatial.transform import Rotation as R
 
-from .utils import keys_to_list, nested_get, nested_set
-
 
 def default(a, b, fraction):
     """Default interpolation for the corresponding type;
@@ -165,46 +163,3 @@ class Interpolation(Enum):
 
 
 InterpolationMap = Dict[str, Interpolation]
-
-
-def interpolate_state(
-    initial_state, final_state, fraction, state_interpolation_map={}
-):
-    """Interpolate a state between two states
-
-    Parameters
-    ----------
-    initial_state : dict
-        Description of initial viewer state.
-    final_state : dict
-        Description of final viewer state.
-    fraction : float
-        Interpolation fraction, must be between `0` and `1`.
-        A value of `0` will return the initial state. A
-        value of `1` will return the final state.
-    state_interpolation_map : dict
-        Dictionary relating state attributes to interpolation functions.
-
-    Returns
-    -------
-    state : dict
-        Description of viewer state.
-    """
-
-    state = dict()
-    separator = "."
-
-    for keys in keys_to_list(initial_state):
-        v0 = nested_get(initial_state, keys)
-        v1 = nested_get(final_state, keys)
-
-        property_string = separator.join(keys)
-
-        if property_string in state_interpolation_map.keys():
-            interpolation_func = state_interpolation_map[property_string]
-        else:
-            interpolation_func = Interpolation.DEFAULT
-
-        nested_set(state, keys, interpolation_func(v0, v1, fraction))
-
-    return state

--- a/napari_animation/key_frame.py
+++ b/napari_animation/key_frame.py
@@ -85,6 +85,15 @@ class ViewerState:
         self.apply(viewer)
         return viewer.screenshot(canvas_only=canvas_only)
 
+    def keys(self):
+        return self.__dataclass_fields__.keys()
+
+    def items(self):
+        return self.__dataclass_fields__.items()
+
+    def get(self, key, value=None):
+        return self.__getitem__(key)
+
     def __eq__(self, other):
         if isinstance(other, ViewerState):
             return (
@@ -94,6 +103,12 @@ class ViewerState:
             )
         else:
             return False
+
+    def __getitem__(self, item):
+        if item in self.keys():
+            return self.__getattribute__(item)
+        else:
+            return super().__getitem__(item)
 
 
 # @dataclass(frozen=True)

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -1,4 +1,5 @@
 import itertools
+import numbers
 
 import numpy as np
 
@@ -93,3 +94,29 @@ def pairwise(iterable):
     a, b = itertools.tee(iterable)
     next(b, None)
     return zip(a, b)
+
+
+def nested_assert_close(a, b):
+    """ Assert close on nested dicts."""
+    a_keys = [key for key in keys_to_list(a)]
+    b_keys = [key for key in keys_to_list(b)]
+
+    assert a_keys == b_keys
+
+    for key in a_keys:
+        a_1 = nested_get(a, key)
+        b_1 = nested_get(b, key)
+
+        nested_seq_assert_close(a_1, b_1)
+
+
+def nested_seq_assert_close(a, b):
+    """Assert close to scalar or potentially nested qequences of numeric types and others."""
+    if isinstance(a, (list, tuple)) or isinstance(b, (list, tuple)):
+        for a_v, b_v in zip(a, b):
+            nested_seq_assert_close(a_v, b_v)
+    else:
+        if isinstance(a, numbers.Number):
+            np.testing.assert_allclose(a, b)
+        else:
+            assert a == b


### PR DESCRIPTION
Interpolation of viewer states is currently based on the nested getters and setters which work with dictionaries, not `ViewerState` objects, meaning we have to first turn our viewerstate into a dictionary with `dataclasses.asdict()`

https://github.com/napari/napari-animation/blob/f38467593df65e224a0573b2e12f2b7cbcb8348c/napari_animation/frame_sequence.py#L134-L145

This PR (which includes #96) solves #89 by adding dict-like methods `__getitem__`, `keys()` and `get()`) on the `ViewerState` which allows us to treat it as a nested dictionary and interpolate as usual.

note: I tried to do this first by modifying the interpolation machinery, my attempts were less clean than this. I fully accept that this may be more complicated than necessary but would be really interested to hear what you guys think? @tlambert03 @Fifourche 
