### PR TITLE
Synced slider with frame index rather than active keyframe

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -96,7 +96,7 @@ class AnimationWidget(QWidget):
         keyframe_list.selection.events.active.connect(
             self._on_active_keyframe_changed
         )
-        self.animation.events._frame_index.connect(
+        self.animation._frames.events._current_index.connect(
             self._on_frame_index_changed
         )
 

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -96,7 +96,9 @@ class AnimationWidget(QWidget):
         keyframe_list.selection.events.active.connect(
             self._on_active_keyframe_changed
         )
-        self.animation.events.frame_index.connect(self._on_frame_index_changed)
+        self.animation.events._set_frame_index.connect(
+            self._on_frame_index_changed
+        )
 
     def _input_state(self):
         """Get current state of input widgets as {key->value} parameters."""

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -96,6 +96,7 @@ class AnimationWidget(QWidget):
         keyframe_list.selection.events.active.connect(
             self._on_active_keyframe_changed
         )
+        self.animation.events.frame_index.connect(self._on_frame_index_changed)
 
     def _input_state(self):
         """Get current state of input widgets as {key->value} parameters."""
@@ -126,27 +127,21 @@ class AnimationWidget(QWidget):
         self.keyframesListWidget.setEnabled(has_frames)
         self.frameWidget.setEnabled(has_frames)
 
-    def _on_active_keyframe_changed(self, event=None):
-        n_frames = len(self.animation._frames)
+    def _on_frame_index_changed(self, event=None):
+        frame_index = event.value
+        self.animationSlider.blockSignals(True)
+        self.animationSlider.setValue(frame_index)
+        self.animationSlider.blockSignals(False)
+
+    def _on_active_keyframe_changed(self, event):
         active_keyframe = event.value
-
-        if active_keyframe and n_frames:
-            self.animationSlider.blockSignals(True)
-            kf1_list = [
-                self.animation._frames._frame_index[n][0]
-                for n in range(n_frames)
-            ]
-            frame_index = kf1_list.index(active_keyframe)
-            self.animationSlider.setValue(frame_index)
-            self.animationSlider.blockSignals(False)
-
         self.keyframesListControlWidget.deleteButton.setEnabled(
             bool(active_keyframe)
         )
 
     def _on_slider_moved(self, event=None):
         frame_index = event
-        if frame_index < len(self.animation._frames) - 1:
+        if frame_index < len(self.animation._frames):
             with self.animation.key_frames.selection.events.active.blocker():
                 self.animation.set_movie_frame_index(frame_index)
 

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -96,7 +96,7 @@ class AnimationWidget(QWidget):
         keyframe_list.selection.events.active.connect(
             self._on_active_keyframe_changed
         )
-        self.animation.events._set_frame_index.connect(
+        self.animation.events._frame_index.connect(
             self._on_frame_index_changed
         )
 
@@ -130,12 +130,14 @@ class AnimationWidget(QWidget):
         self.frameWidget.setEnabled(has_frames)
 
     def _on_frame_index_changed(self, event=None):
+        """Callback on change of last set frame index."""
         frame_index = event.value
         self.animationSlider.blockSignals(True)
         self.animationSlider.setValue(frame_index)
         self.animationSlider.blockSignals(False)
 
     def _on_active_keyframe_changed(self, event):
+        """Callback on change of active keyframe in the key frames list."""
         active_keyframe = event.value
         self.keyframesListControlWidget.deleteButton.setEnabled(
             bool(active_keyframe)

--- a/napari_animation/_tests/test_frame_sequence.py
+++ b/napari_animation/_tests/test_frame_sequence.py
@@ -30,10 +30,10 @@ def test_frame_seq_caching(frame_sequence: FrameSequence):
     ) as mock:
         frame_5 = fs[5]
 
-    # it should have been called once, and a single frame cached
+    # it should have been called once, and a 2 frames cached (the initial one too)
     mock.assert_called_once()
     assert isinstance(frame_5, ViewerState)
-    assert len(fs._cache) == 1
+    assert len(fs._cache) == 2
 
     # indexing the same frame again will not require re-interpolation
     with patch.object(

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -42,7 +42,19 @@ class Animation:
 
         self._frames = FrameSequence(self.key_frames)
 
-        self.events = EmitterGroup(source=self, frame_index=None)
+        # make _set_frame_index an evented attribute
+        self.__set_frame_index = 0
+        self.events = EmitterGroup(source=self, _set_frame_index=None)
+
+    @property
+    def _set_frame_index(self):
+        return self.__set_frame_index
+
+    @_set_frame_index.setter
+    def _set_frame_index(self, frame_index):
+        if frame_index != self._set_frame_index:
+            self.__set_frame_index = frame_index
+            self.events._set_frame_index(value=frame_index)
 
     def capture_keyframe(
         self, steps=15, ease=Easing.LINEAR, insert=True, position: int = None
@@ -117,7 +129,8 @@ class Animation:
                 self.key_frames.selection.active = key_frame
 
             self._frames[index].apply(self.viewer)
-            self.events.frame_index(value=index)
+            self._set_frame_index = index
+
         except KeyError:
             return
 

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import imageio
 import numpy as np
-from napari.utils.events import EmitterGroup
 from napari.utils.io import imsave
 
 from .easing import Easing
@@ -42,20 +41,6 @@ class Animation:
         self._keyframe_counter = count()  # track number of frames created
 
         self._frames = FrameSequence(self.key_frames)
-
-        # make _frame_index an evented attribute
-        self.__frame_index = 0
-        self.events = EmitterGroup(source=self, _frame_index=None)
-
-    @property
-    def _frame_index(self):
-        return self.__frame_index
-
-    @_frame_index.setter
-    def _frame_index(self, frame_index):
-        if frame_index != self._frame_index:
-            self.__frame_index = frame_index
-            self.events._frame_index(value=frame_index)
 
     def capture_keyframe(
         self, steps=15, ease=Easing.LINEAR, insert=True, position: int = None
@@ -128,8 +113,8 @@ class Animation:
             if self.key_frames.selection.active != key_frame:
                 self.key_frames.selection.active = key_frame
 
-            self._frames[index].apply(self.viewer)
-            self._frame_index = index
+            self._frames.set_movie_frame_index(self.viewer, index)
+            self._current_frame = index
 
         except KeyError:
             return

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -57,16 +57,20 @@ class FrameSequence(Sequence[ViewerState]):
         """Create a map of frame number -> (kf0, kf1, fraction)"""
         self._frame_index.clear()
         self._cache.clear()
-        if len(self._key_frames) < 2:
+        if len(self._key_frames) == 0:
             self.events.n_frames(value=len(self))
             return
 
-        f = 0
-        for kf0, kf1 in pairwise(self._key_frames):
-            for s in range(kf1.steps):
-                fraction = s / kf1.steps
-                self._frame_index[f] = (kf0, kf1, fraction)
-                f += 1
+        else:
+            f = 0
+            if len(self._key_frames) == 1:
+                kf1 = self._key_frames[0]
+            else:
+                for kf0, kf1 in pairwise(self._key_frames):
+                    for s in range(kf1.steps):
+                        fraction = s / kf1.steps
+                        self._frame_index[f] = (kf0, kf1, fraction)
+                        f += 1
         self._frame_index[f] = (kf1, kf1, 0)
         self.events.n_frames(value=len(self))
 

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -57,20 +57,22 @@ class FrameSequence(Sequence[ViewerState]):
         """Create a map of frame number -> (kf0, kf1, fraction)"""
         self._frame_index.clear()
         self._cache.clear()
-        if len(self._key_frames) == 0:
+
+        n_keyframes = len(self._key_frames)
+
+        if n_keyframes == 0:
             self.events.n_frames(value=len(self))
             return
-
+        elif n_keyframes == 1:
+            f = 0
+            kf1 = self._key_frames[0]
         else:
             f = 0
-            if len(self._key_frames) == 1:
-                kf1 = self._key_frames[0]
-            else:
-                for kf0, kf1 in pairwise(self._key_frames):
-                    for s in range(kf1.steps):
-                        fraction = s / kf1.steps
-                        self._frame_index[f] = (kf0, kf1, fraction)
-                        f += 1
+            for kf0, kf1 in pairwise(self._key_frames):
+                for s in range(kf1.steps):
+                    fraction = s / kf1.steps
+                    self._frame_index[f] = (kf0, kf1, fraction)
+                    f += 1
         self._frame_index[f] = (kf1, kf1, 0)
         self.events.n_frames(value=len(self))
 


### PR DESCRIPTION
A PR to link the `AnimationSlider` with the frame index being set.

Before it was synced with the change of `key_frames.selection.active`, and now with the signal of an `Emitter` : `frame_index`, added to `Animation`. This way, if we use `set_movie_frame_index`, it'll put the slider at the frame's position and not at the closest key frame.

For some context, the idea I had was to sync the slider with a frame_index signal to prepare the way for a "previewer" capability. The preview would be launched via a method of `Animation`, or a button next to the slider.