### PR TITLE
Fixed deleteButton and easings support

### DIFF
--- a/napari_animation/_qt/keyframelistcontrol_widget.py
+++ b/napari_animation/_qt/keyframelistcontrol_widget.py
@@ -25,6 +25,8 @@ class KeyFrameDeleteButton(QPushButton):
         self.setToolTip("Delete selected key-frame")
         self.setText("Delete")
 
+        self.setEnabled(bool(self.animation.key_frames))
+
 
 class KeyFrameCaptureButton(QPushButton):
     def __init__(self, animation):

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -64,7 +64,7 @@ class FrameSequence(Sequence[ViewerState]):
         f = 0
         for kf0, kf1 in pairwise(self._key_frames):
             for s in range(kf1.steps):
-                fraction = s / kf1.steps
+                fraction = kf1.ease(s / kf1.steps)
                 self._frame_index[f] = (kf0, kf1, fraction)
                 f += 1
         self._frame_index[f] = (kf1, kf1, 0)


### PR DESCRIPTION
There was an issue with easings, that are currently not taken into account ; a small piece of code was missing.
Also, the delete button is enabled by default even when animation contains no keyframe upon initialization.

This PR fixes both !