### PR TITLE
Proof of Concept approach for plugins providing actions

### DIFF
--- a/napari_animation/_hookimpls.py
+++ b/napari_animation/_hookimpls.py
@@ -10,3 +10,16 @@ def napari_experimental_provide_dock_widget():
         "add_vertical_stretch": False,
     }
     return AnimationWidget, widget_options
+
+
+@napari_hook_implementation
+def napari_register_actions():
+    return [
+        (AnimationWidget, "Alt-f", AnimationWidget._capture_keyframe_callback)
+        (AnimationWidget, "Alt-r", AnimationWidget._replace_keyframe_callback)
+        (AnimationWidget, "Alt-d", AnimationWidget._capture_keyframe_callback)
+        (AnimationWidget, "Alt-a", lambda w: w.animation.key_frames.select_next())
+        (AnimationWidget, "Alt-b", lambda w: w.animation.key_frames.select_previous())
+        # ('napari.Viewer', 'alt-f', viewer_function) # To register action to viewer (not used, but illustrative)
+        # ('napari.layers.Points', 'alt-p', points_function) # To register action to points layer (not used, but illustrative)
+    ]

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -65,18 +65,6 @@ class AnimationWidget(QWidget):
         self._add_keybind_callbacks()
         self._add_callbacks()
 
-    def _add_keybind_callbacks(self):
-        """Bind keys"""
-        self._keybindings = [
-            ("Alt-f", self._capture_keyframe_callback),
-            ("Alt-r", self._replace_keyframe_callback),
-            ("Alt-d", self._delete_keyframe_callback),
-            ("Alt-a", lambda e: self.animation.key_frames.select_next()),
-            ("Alt-b", lambda e: self.animation.key_frames.select_previous()),
-        ]
-        for key, cb in self._keybindings:
-            self.viewer.bind_key(key, cb)
-
     def _add_callbacks(self):
         """Establish callbacks"""
         self.keyframesListControlWidget.deleteButton.clicked.connect(
@@ -176,9 +164,3 @@ class AnimationWidget(QWidget):
         self.animationSlider.setEnabled(has_frames)
         self.animationSlider.blockSignals(has_frames)
         self.animationSlider.setMaximum(event.value - 1 if has_frames else 0)
-
-    def closeEvent(self, ev) -> None:
-        # release callbacks
-        for key, _ in self._keybindings:
-            self.viewer.bind_key(key, None)
-        return super().closeEvent(ev)


### PR DESCRIPTION
Here is a potential approach for allowing plugins to providing actions such as keybindings that could then be registered by the action manager that @tlambert03 and I came up with. The big goal was to remove to explicit calls to `viewer.bind_key` and the need for the plugin to clean up its own keybindings and have the "bind" and "unbind" be done by napari through the actions manager, so the shortcut can be changed etc.

The main idea is that there is a new hook_specification `napari_register_actions` that allows a list of actions to be passed. This approach was a little more inspired by how we used to think about providing defaults with the actions themselves, but we should really follow the APIs that @Carreau has already been developing and using in napari, but now just be able to pass plugin dock widgets to these functions and register shortcuts to them.

What we wrote could look something like this

```python
from napari_animation._qt import AnimationWidget


@napari_hook_implementation
def napari_register_actions():
    return [
        (AnimationWidget, "Alt-f", AnimationWidget._capture_keyframe_callback)
        (AnimationWidget, "Alt-r", AnimationWidget._replace_keyframe_callback)
        (AnimationWidget, "Alt-d", AnimationWidget._capture_keyframe_callback)
        (AnimationWidget, "Alt-a", lambda w: w.animation.key_frames.select_next())
        (AnimationWidget, "Alt-b", lambda w: w.animation.key_frames.select_previous())
        # ('napari.Viewer', 'alt-f', viewer_function) # To register action to viewer (not used in this repo, but illustrative)
        # ('napari.layers.Points', 'alt-p', points_function) # To register action to points layer (not used in this repo, but illustrative)
    ]
```

We will need to think about how napari can receive these actions, and how/ when they will get called, but that is on the napari side, not the plugin side.

Curious what @Carreau thinks about this. Might probably be good to have a dedicated meeting with @Carreau @ppwadhwa @goanpeca too to discuss this as we start thinking about it more!! cc @jni @alisterburt 