### PR TITLE
refactor viewer state into its own file

### DIFF
--- a/napari_animation/__init__.py
+++ b/napari_animation/__init__.py
@@ -1,4 +1,5 @@
 from ._hookimpls import napari_experimental_provide_dock_widget
 from ._qt import AnimationWidget
 from .animation import Animation
-from .key_frame import KeyFrame, ViewerState
+from .key_frame import KeyFrame
+from .viewer_state import ViewerState

--- a/napari_animation/_tests/conftest.py
+++ b/napari_animation/_tests/conftest.py
@@ -5,8 +5,7 @@ https://docs.pytest.org/en/stable/fixture.html
 import numpy as np
 import pytest
 
-from napari_animation import Animation
-from napari_animation.key_frame import ViewerState
+from napari_animation import Animation, ViewerState
 
 
 @pytest.fixture

--- a/napari_animation/_tests/test_frame_sequence.py
+++ b/napari_animation/_tests/test_frame_sequence.py
@@ -3,8 +3,8 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+from napari_animation import ViewerState
 from napari_animation.frame_sequence import FrameSequence
-from napari_animation.key_frame import ViewerState
 
 
 def test_frame_seq(frame_sequence: FrameSequence):

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -23,8 +23,8 @@ class Animation:
 
     Attributes
     ----------
-    key_frames : list of dict
-        List of viewer state dictionaries.
+    key_frames : list of KeyFrame
+        List of key-frames in the animation.
     """
 
     def __init__(self, viewer):

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -7,8 +7,8 @@ import numpy as np
 from napari.utils.events import EmitterGroup
 
 from .interpolation import Interpolation, InterpolationMap
-from .key_frame import ViewerState
 from .utils import pairwise
+from .viewer_state import ViewerState
 
 if TYPE_CHECKING:
     import napari

--- a/napari_animation/key_frame.py
+++ b/napari_animation/key_frame.py
@@ -8,92 +8,10 @@ from napari.utils.events import SelectableEventedList
 
 from .easing import Easing
 from .utils import make_thumbnail
+from .viewer_state import ViewerState
 
 if TYPE_CHECKING:
     import napari
-
-
-@dataclass(frozen=True)
-class ViewerState:
-    """The state of the viewer camera, dims, and layers.
-
-    Parameters
-    ----------
-    camera : dict
-        The state of the `napari.components.Camera` in the viewer.
-    dims : dict
-        The state of the `napari.components.Dims` in the viewer.
-    layers : dict
-        A map of layer.name -> _base_state for each layer in the viewer
-        (excluding metadata).
-    """
-
-    camera: dict
-    dims: dict
-    layers: dict
-
-    @classmethod
-    def from_viewer(cls, viewer: napari.viewer.Viewer):
-        """Create a ViewerState from a viewer instance."""
-        layers = {
-            layer.name: layer._get_base_state() for layer in viewer.layers
-        }
-        for d in layers.values():
-            d.pop("metadata")
-        return cls(
-            camera=viewer.camera.dict(), dims=viewer.dims.dict(), layers=layers
-        )
-
-    def apply(self, viewer: napari.viewer.Viewer):
-        """Update `viewer` to match this ViewerState.
-
-        Parameters
-        ----------
-        viewer : napari.viewer.Viewer
-            A napari viewer. (viewer state will be directly modified)
-        """
-
-        viewer.camera.update(self.camera)
-        viewer.dims.update(self.dims)
-
-        for layer_name, layer_state in self.layers.items():
-            layer = viewer.layers[layer_name]
-            for key, value in layer_state.items():
-                original_value = getattr(layer, key)
-                # Only set if value differs to avoid expensive redraws
-                if not np.array_equal(original_value, value):
-                    setattr(layer, key, value)
-
-    def render(
-        self, viewer: napari.viewer.Viewer, canvas_only=True
-    ) -> np.ndarray:
-        """Render this ViewerState to an image.
-
-        Parameters
-        ----------
-        viewer : napari.viewer.Viewer
-            A napari viewer to render screenshots from.
-        canvas_only : bool, optional
-            Whether to include only the canvas (and exclude the napari
-            gui), by default True
-
-        Returns
-        -------
-        np.ndarray
-            An RGBA image of shape (h, w, 4).
-        """
-        self.apply(viewer)
-        return viewer.screenshot(canvas_only=canvas_only, flash=False)
-
-    def __eq__(self, other):
-        if isinstance(other, ViewerState):
-            return (
-                self.camera == other.camera
-                and self.dims == other.dims
-                and self.layers == other.layers
-            )
-        else:
-            return False
 
 
 # @dataclass(frozen=True)
@@ -103,7 +21,7 @@ class KeyFrame:
 
     Parameters
     ----------
-    viewer_state : ViewerState
+    viewer_state : napari_animation.ViewerState
         The state of the viewer at this keyframe.
     thumbnail : np.ndarray
         A thumbnail representing this keyframe.

--- a/napari_animation/viewer_state.py
+++ b/napari_animation/viewer_state.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+import napari
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ViewerState:
+    """The state of the viewer camera, dims, and layers.
+
+    Parameters
+    ----------
+    camera : dict
+        The state of the `napari.components.Camera` in the viewer.
+    dims : dict
+        The state of the `napari.components.Dims` in the viewer.
+    layers : dict
+        A map of layer.name -> _base_state for each layer in the viewer
+        (excluding metadata).
+    """
+
+    camera: dict
+    dims: dict
+    layers: dict
+
+    @classmethod
+    def from_viewer(cls, viewer: napari.viewer.Viewer):
+        """Create a ViewerState from a viewer instance."""
+        layers = {
+            layer.name: layer._get_base_state() for layer in viewer.layers
+        }
+        for d in layers.values():
+            d.pop("metadata")
+        return cls(
+            camera=viewer.camera.dict(), dims=viewer.dims.dict(), layers=layers
+        )
+
+    def apply(self, viewer: napari.viewer.Viewer):
+        """Update `viewer` to match this ViewerState.
+
+        Parameters
+        ----------
+        viewer : napari.viewer.Viewer
+            A napari viewer. (viewer state will be directly modified)
+        """
+
+        viewer.camera.update(self.camera)
+        viewer.dims.update(self.dims)
+
+        for layer_name, layer_state in self.layers.items():
+            layer = viewer.layers[layer_name]
+            for key, value in layer_state.items():
+                original_value = getattr(layer, key)
+                # Only set if value differs to avoid expensive redraws
+                if not np.array_equal(original_value, value):
+                    setattr(layer, key, value)
+
+    def render(
+        self, viewer: napari.viewer.Viewer, canvas_only=True
+    ) -> np.ndarray:
+        """Render this ViewerState to an image.
+
+        Parameters
+        ----------
+        viewer : napari.viewer.Viewer
+            A napari viewer to render screenshots from.
+        canvas_only : bool, optional
+            Whether to include only the canvas (and exclude the napari
+            gui), by default True
+
+        Returns
+        -------
+        np.ndarray
+            An RGBA image of shape (h, w, 4).
+        """
+        self.apply(viewer)
+        return viewer.screenshot(canvas_only=canvas_only)
+
+    def __eq__(self, other):
+        if isinstance(other, ViewerState):
+            return (
+                self.camera == other.camera
+                and self.dims == other.dims
+                and self.layers == other.layers
+            )
+        else:
+            return False


### PR DESCRIPTION
I kept mis-remembering where the `ViewerState` object was kept - this feels cleaner