### PR TITLE
Include napari version information in output video metadata

### DIFF
--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -1,5 +1,3 @@
-import os
-import subprocess
 from unittest.mock import patch
 
 import numpy as np
@@ -119,13 +117,12 @@ def test_animation_file_metadata(animation_with_key_frames, tmp_path, ext):
     output_filename = tmp_path / f"test{ext}"
     animation.animate(output_filename)
     # Read metadata back in, and check for napari version information
-    output_metadata_filename = os.path.splitext(output_filename)[0] + ext.replace('.', '-') + ".txt"
-    subprocess.run(f"ffmpeg -i {output_filename} -f ffmetadata {output_metadata_filename}", shell=True, check=True)
-    with open(output_metadata_filename) as f:
-        content = f.read()
     # We expect to see a metadata line in the metadata like this:
     # title="napari version 0.4.17 https://napari.org/"
-    assert 'title="napari version' in content
+    with open(output_filename, 'rb') as f:
+        content = f.read()
+    assert b"napari version" in content
+    assert b"https://napari.org" in content
 
 
 @pytest.mark.parametrize("attribute", CAPTURED_LAYER_ATTRIBUTES)

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -119,7 +119,7 @@ def test_animation_file_metadata(animation_with_key_frames, tmp_path, ext):
     # Read metadata back in, and check for napari version information
     # We expect to see a metadata line in the metadata like this:
     # title="napari version 0.4.17 https://napari.org/"
-    with open(output_filename, 'rb') as f:
+    with open(output_filename, "rb") as f:
         content = f.read()
     assert b"napari version" in content
     assert b"https://napari.org" in content

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -110,7 +110,7 @@ def test_animate_filenames(
         assert saved_files == expected
 
 
-@pytest.mark.parametrize("ext", [".mp4", ".mov", ".avi", ""])
+@pytest.mark.parametrize("ext", [".mp4", ".mov", ".avi"])
 def test_animation_file_metadata(animation_with_key_frames, tmp_path, ext):
     """Test output video file contians napari version metadata()"""
     animation = animation_with_key_frames

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -5,8 +5,8 @@ from time import sleep
 
 import imageio
 import numpy as np
-from napari.utils.io import imsave
 from napari._version import __version__
+from napari.utils.io import imsave
 from tqdm import tqdm
 
 from napari_animation.easing import Easing
@@ -157,7 +157,7 @@ class Animation:
         self._validate_animation()
 
         description = f"napari version {__version__} https://napari.org/"
-        output_params = ['-metadata', f'title="{description}"']
+        output_params = ["-metadata", f'title="{description}"']
 
         # create path object
         file_path = Path(filename)
@@ -191,7 +191,9 @@ class Animation:
                     )
                 else:
                     writer = imageio.get_writer(
-                        filename, fps=fps, format=format,
+                        filename,
+                        fps=fps,
+                        format=format,
                         output_params=output_params,
                     )
             except ValueError as err:

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -156,8 +156,8 @@ class Animation:
         """
         self._validate_animation()
 
-        descr = f"napari version {__version__} https://napari.org/"
-        output_params = [f'-metadata title=napari']
+        description = f"napari version {__version__} https://napari.org/"
+        output_params = ['-metadata', f'title="{description}"']
 
         # create path object
         file_path = Path(filename)

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -5,7 +5,7 @@ from time import sleep
 
 import imageio
 import numpy as np
-from napari._version import __version__
+from napari._version import __version__ as napari_version
 from napari.utils.io import imsave
 from tqdm import tqdm
 
@@ -156,7 +156,7 @@ class Animation:
         """
         self._validate_animation()
 
-        description = f"napari version {__version__} https://napari.org/"
+        description = f"napari version {napari_version} https://napari.org/"
         output_params = ["-metadata", f'title="{description}"']
 
         # create path object

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -6,6 +6,7 @@ from time import sleep
 import imageio
 import numpy as np
 from napari.utils.io import imsave
+from napari._version import __version__
 from tqdm import tqdm
 
 from napari_animation.easing import Easing
@@ -155,6 +156,9 @@ class Animation:
         """
         self._validate_animation()
 
+        descr = f"napari version {__version__} https://napari.org/"
+        output_params = [f'-metadata title=napari']
+
         # create path object
         file_path = Path(filename)
         folder_path = file_path.absolute().parent.joinpath(file_path.stem)
@@ -183,10 +187,12 @@ class Animation:
                         fps=fps,
                         quality=quality,
                         format=format,
+                        output_params=output_params,
                     )
                 else:
                     writer = imageio.get_writer(
-                        filename, fps=fps, format=format
+                        filename, fps=fps, format=format,
+                        output_params=output_params,
                     )
             except ValueError as err:
                 print(err)


### PR DESCRIPTION
## Description

Companion to PR https://github.com/napari/napari/pull/5494

This adds a digital watermark to the video files output by napari-animation. That means in the future it may be possible to scrape publications & supplementary data, eg: like this analysis done for matplotlib https://github.com/mrocklin/arxiv-matplotlib

## Try it out!

Now, you can run the examples to create a video file:
```python
python napari-animation/examples/animate2d.py
```
...and then look at the metadata embedded in the video file header with ffmpeg. This ffmpeg command writes the metadata to a text file:
```
!ffmpeg -i demo2d.mov -f ffmetadata FFMETADATAFILE.txt
```
And when you look at the output
```
cat FFMETADATAFILE.txt
```
...you see something like this (note the new "title" metadata field, which was not there before:
```
;FFMETADATA1
major_brand=qt  
minor_version=512
compatible_brands=qt  
title="napari version 0.4.17 https://napari.org/"
encoder=Lavf59.27.100
```

Actually, here is a simpler way to read the metadata from the video file:
```python
    # Read metadata back in, and check for napari version information
    # We expect to see a metadata line in the metadata like this:
    # title="napari version 0.4.17 https://napari.org/"
    with open(output_video_filename, 'rb') as f:
        content = f.read()
    assert b"napari version" in content
    assert b"https://napari.org" in content
```

## Additional details

I have stuffed the napari version information into the "title" metadata key, because that seems to be the most widely available. (.mp4 files do allow a "description" metadata field, but that is *not* supported by .avi, .mov, and possibly many other file formats).
