### PR TITLE
Easily display video output in jupyter notebooks

### DIFF
--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -248,5 +248,8 @@ class Animation:
             self.set_key_frame_index(keyframe_index)
 
     def _repr_html_(self):
-        html = f'<video width="100%" height="100%" controls> <source src="{self._filename}"> </video>'
-        return html
+        if self._filename is None:
+            return None
+        else:
+            html = f'<video width="100%" height="100%" controls> <source src="{self._filename}"> </video>'
+            return html

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -249,7 +249,7 @@ class Animation:
 
     def _repr_html_(self):
         if self._filename is None:
-            return None
+            return 'Video animation not yet available (use the "animate" method to generate it).'
         else:
             html = f'<video width="100%" height="100%" controls> <source src="{self._filename}"> </video>'
             return html

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -45,6 +45,8 @@ class Animation:
 
         self._frames = FrameSequence(self.key_frames)
 
+        self._filename = None
+
     def capture_keyframe(
         self, steps=15, ease=Easing.LINEAR, insert=True, position: int = None
     ):
@@ -158,6 +160,7 @@ class Animation:
         # create path object
         file_path = Path(filename)
         folder_path = file_path.absolute().parent.joinpath(file_path.stem)
+        self._filename = file_path
 
         # if path has no extension, save as fold of PNG
         save_as_folder = False
@@ -243,3 +246,7 @@ class Animation:
         if active_keyframe:
             keyframe_index = self.key_frames.index(active_keyframe)
             self.set_key_frame_index(keyframe_index)
+
+    def _repr_html_(self):
+        html = f'<video width="100%" height="100%" controls> <source src="{self._filename}"> </video>'
+        return html


### PR DESCRIPTION
Closes https://github.com/napari/napari-animation/issues/147

This PR adds a `_repr_html_` method to the `Animation` class, so that it will automatically display the video once the filename is known (i.e. after the `animate` method has been run).

![Screen Shot 2023-05-01 at 5 11 16 pm](https://user-images.githubusercontent.com/30920819/235423257-fa81b247-c864-4736-b881-1c84eedf6f5c.png)
