### PR TITLE
Add gif display to _repr_html_ for jupyter notebooks

### DIFF
--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -257,7 +257,9 @@ class Animation:
 
     def _repr_html_(self):
         if self._filename is None:
-            return 'Video animation not yet available (use the "animate" method to generate it).'
+            html = 'Video animation not yet available (use the "animate" method to generate it).'
+        elif str(self._filename).endswith(".gif"):
+            html = f'<img src="{self._filename}">'
         else:
             html = f'<video width="100%" height="100%" controls> <source src="{self._filename}"> </video>'
-            return html
+        return html


### PR DESCRIPTION
Allows jupyter notebooks to automatically display gif animations, similarly to the video formats.

Follow up to https://github.com/napari/napari-animation/pull/170/files

See comment here https://github.com/napari/napari-animation/pull/170#issuecomment-1529723124
