### PR TITLE
Handle namedtuple

### DIFF
--- a/napari_animation/_tests/test_interpolation.py
+++ b/napari_animation/_tests/test_interpolation.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 
 import numpy as np
 import pytest
+from typing import NamedTuple
 
 from napari_animation.interpolation import interpolate_viewer_state
 from napari_animation.interpolation.base_interpolation import (
@@ -72,3 +73,21 @@ def test_interpolate_viewer_state(frame_sequence, fraction):
 
     # else:
     # should find something else to test
+
+
+class NTuple(NamedTuple):
+    a: float
+    b: int
+
+
+@pytest.mark.parametrize(
+    "fraction,expected",
+    [(0.0, (0.0, 0)), (0.5, (0.5, 0)), (1.0, (1.0, 1))],
+)
+def test_interpolate_namedtuple(fraction, expected):
+    initial_state = NTuple(a=0.0, b=0)
+    final_state = NTuple(a=1.0, b=1)
+    expected = NTuple(*expected)
+    result = interpolate_sequence(initial_state, final_state, fraction)
+    assert isinstance(result, NTuple)
+    assert result == expected

--- a/napari_animation/_tests/test_interpolation.py
+++ b/napari_animation/_tests/test_interpolation.py
@@ -1,8 +1,8 @@
 from dataclasses import asdict
+from typing import NamedTuple
 
 import numpy as np
 import pytest
-from typing import NamedTuple
 
 from napari_animation.interpolation import interpolate_viewer_state
 from napari_animation.interpolation.base_interpolation import (

--- a/napari_animation/interpolation/base_interpolation.py
+++ b/napari_animation/interpolation/base_interpolation.py
@@ -1,5 +1,5 @@
 from numbers import Number
-from typing import Sequence, Tuple, TypeVar, NamedTuple
+from typing import Sequence, Tuple, TypeVar
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R

--- a/napari_animation/interpolation/base_interpolation.py
+++ b/napari_animation/interpolation/base_interpolation.py
@@ -1,5 +1,5 @@
 from numbers import Number
-from typing import Sequence, Tuple, TypeVar
+from typing import Sequence, Tuple, TypeVar, NamedTuple
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R
@@ -58,9 +58,13 @@ def interpolate_sequence(
     Interpolated sequence between a and b at fraction.
     """
     seq_cls = type(a)
-    return seq_cls(
-        default_interpolation(v0, v1, fraction) for v0, v1 in zip(a, b)
-    )
+    gen = (default_interpolation(v0, v1, fraction) for v0, v1 in zip(a, b))
+    try:
+        seq = seq_cls(gen)
+    except TypeError:
+        # some interables, like NamedTuple, want the arguments separately
+        seq = seq_cls(*gen)
+    return seq
 
 
 def interpolate_num(a: Number, b: Number, fraction: float) -> Number:


### PR DESCRIPTION
On the current napari main, `Dims.range` is a `NamedTuple`. This break napari-animation because namedtuples want arguments separately, rather than as a single iterable. This PR adds a fallback for when the current behaviour fails.

We *could* check types instead of using exceptions for control flow, but things get complicated with generics, so I ended up with this instead.
