### PR TITLE
[Bugfix] For `layer_attributes` that are dict (like `color`) do key/value comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ target/
 
 # written by setuptools_scm
 */_version.py
+
+# vscode
+.vscode

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -2,7 +2,10 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+import os.path
 
+from napari._tests.utils import add_layer_by_type, layer_test_data
+    
 from napari_animation import Animation, ViewerState
 from napari_animation.utils import make_thumbnail
 
@@ -139,3 +142,15 @@ def test_end_state_reached(image_animation):
     image_animation.capture_keyframe(steps=2)
     last_state = image_animation._frames[-1]
     assert last_state == image_animation.key_frames[-1].viewer_state
+
+@pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
+def test_animating_all_layer_types(make_napari_viewer, layer_class, data, ndim, tmp_path):
+    """Test that all napari layer types can be animated"""
+    viewer = make_napari_viewer()
+    add_layer_by_type(viewer, layer_class, data, visible=True)
+    layer_animation = Animation(viewer)
+    layer_animation.capture_keyframe()
+    layer_animation.viewer.camera.zoom *= 2
+    layer_animation.capture_keyframe()
+    layer_animation.animate(tmp_path / 'test.mp4')
+    assert os.path.exists(tmp_path / 'test.mp4')

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -7,7 +7,6 @@ from napari._tests.utils import (
     assert_layer_state_equal,
     layer_test_data,
 )
-from napari.layers import Surface
 
 from napari_animation import Animation, ViewerState
 from napari_animation.utils import make_thumbnail
@@ -159,14 +158,7 @@ def test_attributes_for_all_layer_types(
     layer_state = viewer.layers[0]._get_state()
     # remove attributes that arn't captured
     layer_state.pop("metadata")
-    layer_state.pop("ndim", None)
-    layer_state.pop("property_choices", None)
-    layer_state.pop("colormaps_dict", None)
-    layer_state.pop("data")
-    # these have `allow_mutation=False` so can't be set
-    if layer_class == Surface:
-        layer_state["normals"]["face"].pop("mode", None)
-        layer_state["normals"]["vertex"].pop("mode", None)
+    layer_state.pop("data", None)
 
     layer_animation.capture_keyframe()
     # get the layer attributes captured to viewer_state

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -7,7 +7,6 @@ from napari._tests.utils import (
     assert_layer_state_equal,
     layer_test_data,
 )
-from napari.layers import Surface
 
 from napari_animation import Animation, ViewerState
 from napari_animation.utils import make_thumbnail
@@ -160,10 +159,6 @@ def test_attributes_for_all_layer_types(
     # remove attributes that arn't captured
     layer_state.pop("metadata")
     layer_state.pop("data", None)
-
-    if layer_class == Surface:
-        layer_state["normals"]["face"].pop("mode", None)
-        layer_state["normals"]["vertex"].pop("mode", None)
 
     layer_animation.capture_keyframe()
     # get the layer attributes captured to viewer_state

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import os.path
 import numpy as np
 import pytest
 import os.path
@@ -8,6 +9,7 @@ from napari._tests.utils import add_layer_by_type, layer_test_data
     
 from napari_animation import Animation, ViewerState
 from napari_animation.utils import make_thumbnail
+from napari._tests.utils import add_layer_by_type, layer_test_data
 
 CAPTURED_LAYER_ATTRIBUTES = [
     "name",

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -7,6 +7,7 @@ from napari._tests.utils import (
     assert_layer_state_equal,
     layer_test_data,
 )
+from napari.layers import Surface
 
 from napari_animation import Animation, ViewerState
 from napari_animation.utils import make_thumbnail
@@ -163,8 +164,9 @@ def test_attributes_for_all_layer_types(
     layer_state.pop("colormaps_dict", None)
     layer_state.pop("data")
     # these have `allow_mutation=False` so can't be set
-    layer_state["normals"]["face"].pop("mode", None)
-    layer_state["normals"]["vertex"].pop("mode", None)
+    if layer_class == Surface:
+        layer_state["normals"]["face"].pop("mode", None)
+        layer_state["normals"]["vertex"].pop("mode", None)
 
     layer_animation.capture_keyframe()
     # get the layer attributes captured to viewer_state

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -1,15 +1,12 @@
+import os.path
 from unittest.mock import patch
 
-import os.path
 import numpy as np
 import pytest
-import os.path
-
 from napari._tests.utils import add_layer_by_type, layer_test_data
-    
+
 from napari_animation import Animation, ViewerState
 from napari_animation.utils import make_thumbnail
-from napari._tests.utils import add_layer_by_type, layer_test_data
 
 CAPTURED_LAYER_ATTRIBUTES = [
     "name",
@@ -145,8 +142,11 @@ def test_end_state_reached(image_animation):
     last_state = image_animation._frames[-1]
     assert last_state == image_animation.key_frames[-1].viewer_state
 
-@pytest.mark.parametrize('layer_class, data, ndim', layer_test_data)
-def test_animating_all_layer_types(make_napari_viewer, layer_class, data, ndim, tmp_path):
+
+@pytest.mark.parametrize("layer_class, data, ndim", layer_test_data)
+def test_animating_all_layer_types(
+    make_napari_viewer, layer_class, data, ndim, tmp_path
+):
     """Test that all napari layer types can be animated"""
     viewer = make_napari_viewer()
     add_layer_by_type(viewer, layer_class, data, visible=True)
@@ -154,5 +154,5 @@ def test_animating_all_layer_types(make_napari_viewer, layer_class, data, ndim, 
     layer_animation.capture_keyframe()
     layer_animation.viewer.camera.zoom *= 2
     layer_animation.capture_keyframe()
-    layer_animation.animate(tmp_path / 'test.mp4')
-    assert os.path.exists(tmp_path / 'test.mp4')
+    layer_animation.animate(tmp_path / "test.mp4")
+    assert os.path.exists(tmp_path / "test.mp4")

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -7,6 +7,7 @@ from napari._tests.utils import (
     assert_layer_state_equal,
     layer_test_data,
 )
+from napari.layers import Surface
 
 from napari_animation import Animation, ViewerState
 from napari_animation.utils import make_thumbnail
@@ -159,6 +160,10 @@ def test_attributes_for_all_layer_types(
     # remove attributes that arn't captured
     layer_state.pop("metadata")
     layer_state.pop("data", None)
+
+    if layer_class == Surface:
+        layer_state["normals"]["face"].pop("mode", None)
+        layer_state["normals"]["vertex"].pop("mode", None)
 
     layer_animation.capture_keyframe()
     # get the layer attributes captured to viewer_state

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -162,6 +162,9 @@ def test_attributes_for_all_layer_types(
     layer_state.pop("property_choices", None)
     layer_state.pop("colormaps_dict", None)
     layer_state.pop("data")
+    # these have `allow_mutation=False` so can't be set
+    layer_state["normals"]["face"].pop("mode", None)
+    layer_state["normals"]["vertex"].pop("mode", None)
 
     layer_animation.capture_keyframe()
     # get the layer attributes captured to viewer_state

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -1,4 +1,3 @@
-import os.path
 from unittest.mock import patch
 
 import numpy as np
@@ -154,5 +153,5 @@ def test_animating_all_layer_types(
     layer_animation.capture_keyframe()
     layer_animation.viewer.camera.zoom *= 2
     layer_animation.capture_keyframe()
-    layer_animation.animate(tmp_path / "test.mp4")
-    assert os.path.exists(tmp_path / "test.mp4")
+    # advance the movie frame, simulating slider movement
+    layer_animation.set_movie_frame_index(1)

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -147,7 +147,9 @@ def test_end_state_reached(image_animation):
 
 
 @pytest.mark.parametrize("layer_class, data, ndim", layer_test_data)
-def test_attributes_for_all_layer_types(make_napari_viewer, layer_class, data):
+def test_attributes_for_all_layer_types(
+    make_napari_viewer, layer_class, data, ndim
+):
     """Test that attributes are in the viewer_state for all napari layer types"""
     viewer = make_napari_viewer()
     add_layer_by_type(viewer, layer_class, data, visible=True)
@@ -171,7 +173,9 @@ def test_attributes_for_all_layer_types(make_napari_viewer, layer_class, data):
 
 
 @pytest.mark.parametrize("layer_class, data, ndim", layer_test_data)
-def test_animating_all_layer_types(make_napari_viewer, layer_class, data):
+def test_animating_all_layer_types(
+    make_napari_viewer, layer_class, data, ndim
+):
     """Test that all napari layer types can be animated"""
     viewer = make_napari_viewer()
     add_layer_by_type(viewer, layer_class, data, visible=True)

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -22,6 +22,11 @@ CAPTURED_IMAGE_LAYER_ATTRIBUTES = [
     "visible",
 ]
 
+NOT_CAPTURED_LAYER_ATTRIBUTES = [
+    "metadata",
+    "data",
+]
+
 
 def test_animation(make_napari_viewer):
     """Test creation of an animation class."""
@@ -157,8 +162,8 @@ def test_attributes_for_all_layer_types(
     # get the state of the layer
     layer_state = viewer.layers[0]._get_state()
     # remove attributes that arn't captured
-    layer_state.pop("metadata")
-    layer_state.pop("data", None)
+    for key in NOT_CAPTURED_LAYER_ATTRIBUTES:
+        layer_state.pop(key)
 
     layer_animation.capture_keyframe()
     # get the layer attributes captured to viewer_state

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -161,7 +161,7 @@ def test_attributes_for_all_layer_types(
     layer_animation = Animation(viewer)
     # get the state of the layer
     layer_state = viewer.layers[0]._get_state()
-    # remove attributes that arn't captured
+    # remove attributes that are not captured
     for key in NOT_CAPTURED_LAYER_ATTRIBUTES:
         layer_state.pop(key)
 

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -16,6 +16,7 @@ CAPTURED_LAYER_ATTRIBUTES = [
     "opacity",
     "blending",
     "visible",
+    "color",
 ]
 
 

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -31,3 +31,16 @@ def pairwise(iterable):
     a, b = itertools.tee(iterable)
     next(b, None)
     return zip(a, b)
+
+def check_layer_attribute_changed(value, original_value):
+    """Recursively check if a layer attribute has changed."""
+    changed = False
+    if isinstance(value, dict):
+        for key in value.keys():
+            if check_layer_attribute_changed(value[key], original_value[key]):
+                changed = True
+                break
+    else: 
+        changed = not np.array_equal(value, original_value)
+
+    return changed

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -33,13 +33,16 @@ def pairwise(iterable):
     return zip(a, b)
 
 
-def check_layer_attribute_changed(value, original_value):
+def layer_attribute_changed(value, original_value):
     """Recursively check if a layer attribute has changed."""
     if isinstance(value, dict):
-        if not isinstance(original_value, dict) or value.keys() != original_value.keys():
+        if (
+            not isinstance(original_value, dict)
+            or value.keys() != original_value.keys()
+        ):
             return True
         for key in value.keys():
-            if check_layer_attribute_changed(value[key], original_value[key]):
+            if layer_attribute_changed(value[key], original_value[key]):
                 return True
-
-    return not np.array_equal(value, original_value)
+    else:
+        return not np.array_equal(value, original_value)

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -41,8 +41,8 @@ def layer_attribute_changed(value, original_value):
             or value.keys() != original_value.keys()
         ):
             return True
-        for key in value.keys():
-            if layer_attribute_changed(value[key], original_value[key]):
-                return True
-    else:
-        return not np.array_equal(value, original_value)
+        return any(
+            layer_attribute_changed(value[key], original_value[key])
+            for key in value.keys()
+        )
+    return not np.array_equal(value, original_value)

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -32,6 +32,7 @@ def pairwise(iterable):
     next(b, None)
     return zip(a, b)
 
+
 def check_layer_attribute_changed(value, original_value):
     """Recursively check if a layer attribute has changed."""
     changed = False
@@ -40,7 +41,7 @@ def check_layer_attribute_changed(value, original_value):
             if check_layer_attribute_changed(value[key], original_value[key]):
                 changed = True
                 break
-    else: 
+    else:
         changed = not np.array_equal(value, original_value)
 
     return changed

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -35,13 +35,11 @@ def pairwise(iterable):
 
 def check_layer_attribute_changed(value, original_value):
     """Recursively check if a layer attribute has changed."""
-    changed = False
     if isinstance(value, dict):
+        if not isinstance(original_value, dict) or value.keys() != original_value.keys():
+            return True
         for key in value.keys():
             if check_layer_attribute_changed(value[key], original_value[key]):
-                changed = True
-                break
-    else:
-        changed = not np.array_equal(value, original_value)
+                return True
 
-    return changed
+    return not np.array_equal(value, original_value)

--- a/napari_animation/viewer_state.py
+++ b/napari_animation/viewer_state.py
@@ -32,6 +32,10 @@ class ViewerState:
         }
         for layer_attributes in layers.values():
             layer_attributes.pop("metadata")
+            # the following can't be set as attributes
+            layer_attributes.pop("property_choices", None)
+            layer_attributes.pop("ndim", None)
+            layer_attributes.pop("colormaps_dict", None)
             
         return cls(
             camera=viewer.camera.dict(), dims=viewer.dims.dict(), layers=layers

--- a/napari_animation/viewer_state.py
+++ b/napari_animation/viewer_state.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import napari
 import numpy as np
 
-from napari_animation.utils import check_layer_attribute_changed
+from napari_animation.utils import layer_attribute_changed
 
 
 @dataclass(frozen=True)
@@ -62,7 +62,7 @@ class ViewerState:
                 original_value = layer_attributes[attribute_name]
                 # Only setattr if value differs to avoid expensive redraws
                 # dicts can hold arrays, e.g. `color`, requiring comparisons of key/value pairs
-                if not check_layer_attribute_changed(value, original_value):
+                if not layer_attribute_changed(value, original_value):
                     setattr(layer, attribute_name, value)
 
     def render(

--- a/napari_animation/viewer_state.py
+++ b/napari_animation/viewer_state.py
@@ -34,10 +34,6 @@ class ViewerState:
         }
         for layer_attributes in layers.values():
             layer_attributes.pop("metadata")
-            # the following can't be set as attributes
-            layer_attributes.pop("property_choices", None)
-            layer_attributes.pop("ndim", None)
-            layer_attributes.pop("colormaps_dict", None)
 
         return cls(
             camera=viewer.camera.dict(), dims=viewer.dims.dict(), layers=layers
@@ -63,7 +59,10 @@ class ViewerState:
                 # Only setattr if value differs to avoid expensive redraws
                 # dicts can hold arrays, e.g. `color`, requiring comparisons of key/value pairs
                 if not layer_attribute_changed(value, original_value):
-                    setattr(layer, attribute_name, value)
+                    try:
+                        setattr(layer, attribute_name, value)
+                    except AttributeError:
+                        pass
 
     def render(
         self, viewer: napari.viewer.Viewer, canvas_only: bool = True

--- a/napari_animation/viewer_state.py
+++ b/napari_animation/viewer_state.py
@@ -56,9 +56,9 @@ class ViewerState:
             layer_attributes = layer.as_layer_data_tuple()[1]
             for attribute_name, value in layer_state.items():
                 original_value = layer_attributes[attribute_name]
-                # Only setattr if value differs to avoid expensive redraws
+                # Only setattr if value has changed to avoid expensive redraws
                 # dicts can hold arrays, e.g. `color`, requiring comparisons of key/value pairs
-                if not layer_attribute_changed(value, original_value):
+                if layer_attribute_changed(value, original_value):
                     try:
                         setattr(layer, attribute_name, value)
                     except AttributeError:

--- a/napari_animation/viewer_state.py
+++ b/napari_animation/viewer_state.py
@@ -4,6 +4,8 @@ import napari
 import numpy as np
 
 from napari_animation.utils import check_layer_attribute_changed
+
+
 @dataclass(frozen=True)
 class ViewerState:
     """The state of the viewer camera, dims, and layers.
@@ -36,7 +38,7 @@ class ViewerState:
             layer_attributes.pop("property_choices", None)
             layer_attributes.pop("ndim", None)
             layer_attributes.pop("colormaps_dict", None)
-            
+
         return cls(
             camera=viewer.camera.dict(), dims=viewer.dims.dict(), layers=layers
         )
@@ -62,8 +64,6 @@ class ViewerState:
                 # dicts can hold arrays, e.g. `color`, requiring comparisons of key/value pairs
                 if not check_layer_attribute_changed(value, original_value):
                     setattr(layer, attribute_name, value)
-
-        
 
     def render(
         self, viewer: napari.viewer.Viewer, canvas_only: bool = True

--- a/napari_animation/viewer_state.py
+++ b/napari_animation/viewer_state.py
@@ -54,8 +54,14 @@ class ViewerState:
             layer_attributes = layer.as_layer_data_tuple()[1]
             for attribute_name, value in layer_state.items():
                 original_value = layer_attributes[attribute_name]
-                # Only set if value differs to avoid expensive redraws
-                if not np.array_equal(original_value, value):
+                # Only setattr if value differs to avoid expensive redraws
+                # dicts can hold arrays, e.g. `color`, requiring comparisons of key/value pairs
+                if type(value) is dict:
+                    for key, val in value.items():
+                        if not np.array_equal(val, original_value.get(key)):
+                            setattr(layer, attribute_name, value)
+                            break
+                elif not np.array_equal(original_value, value):
                     setattr(layer, attribute_name, value)
 
     def render(


### PR DESCRIPTION
Closes: https://github.com/napari/napari-animation/issues/180
Closes: https://github.com/napari/napari-animation/issues/184

This adds a new function to utils.py for carrying out the comparison of layer_attribute. In particular if an attribute is a dict then the function recurses using key/value pairs.
This is needed for example for Labels layer `color` which is a dict of np.array. But other layers also have nested dicts (e.g. Surfaces)

Additionally, I implement two tests that use all napari layers. 
The first compares attributes between viewer_state and the actual layer and the second checks whether the animation has frames.
These tests fail in main but pass with the fix mentioned above.