### PR TITLE
Bugfix: Use importlib.metadata.version instead import from _version

### DIFF
--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -21,7 +21,7 @@ except ImportError:
     except ImportError:
 
         def version(_=None):
-            return "unknown"
+            return "<0.4.15"
 
 
 napari_version = version("napari")

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -5,7 +5,6 @@ from time import sleep
 
 import imageio
 import numpy as np
-from napari._version import __version__ as napari_version
 from napari.utils.io import imsave
 from tqdm import tqdm
 
@@ -13,6 +12,19 @@ from napari_animation.easing import Easing
 
 from .frame_sequence import FrameSequence
 from .key_frame import KeyFrame, KeyFrameList
+
+try:
+    from importlib.metadata import version
+except ImportError:
+    try:
+        from importlib_metadata import version
+    except ImportError:
+
+        def version(_=None):
+            return "unknown"
+
+
+napari_version = version("napari")
 
 
 class Animation:


### PR DESCRIPTION
Closes: https://github.com/napari/napari-animation/issues/177

In this PR I get the napari version using importlib.metadata.version instead of importing from _version.
In older napari versions the variable name was different, resulting in the error shown in #177 
This method should be backwards compatible for any napari on python >= 3.8
To be safe for older python also try importlib_metadata but if that doesn't work, then just note the version as older than 0.4.15, the first version to not support python 3.7.