### PR TITLE
Bugfix: Return empty dict when SaveDialog is canceled

### DIFF
--- a/napari_animation/_qt/savedialog_widget.py
+++ b/napari_animation/_qt/savedialog_widget.py
@@ -65,9 +65,10 @@ class SaveDialogWidget(QFileDialog):
                 "canvas_only": self.optionsWidget.canvasCheckBox.isChecked(),
                 "scale_factor": self.optionsWidget.scaleSpinBox.value(),
             }
-            return animation_kwargs
         else:
-            return ""
+            animation_kwargs = {}
+
+        return animation_kwargs
 
     def get_file_path(self) -> Path:
         provided_file_name = Path(list(self.selectedFiles())[0])


### PR DESCRIPTION
Closes: https://github.com/napari/napari-animation/issues/183
Currently when the SaveDialog is canceled or exited without saving then the return is "" -- an empty string. This doesn't have a `get` method, so it results in a Traceback.

In this PR, I ensure a dict is always returned and in the case of exiting without saving it's just empty.
