### PR TITLE
Use boolean interpolation for `dims.ndisplay`

### DIFF
--- a/napari_animation/_tests/conftest.py
+++ b/napari_animation/_tests/conftest.py
@@ -42,7 +42,7 @@ def frame_sequence(animation_with_key_frames):
 @pytest.fixture
 def image_animation(make_napari_viewer):
     viewer = make_napari_viewer()
-    viewer.add_image(np.random.random((28, 28)))
+    viewer.add_image(np.random.random((2, 28, 28)))
     return Animation(viewer)
 
 

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -151,6 +151,16 @@ def test_end_state_reached(image_animation):
     assert last_state == image_animation.key_frames[-1].viewer_state
 
 
+def test_ndisplay_interpolation(image_animation):
+    """Check that dims.ndisplay interpolation is boolean"""
+    image_animation.capture_keyframe()
+    image_animation.viewer.dims.ndisplay = 3
+    image_animation.capture_keyframe(steps=3)
+    assert image_animation._frames[0].dims["ndisplay"] == 2
+    assert image_animation._frames[1].dims["ndisplay"] == 3
+    assert image_animation._frames[-1].dims["ndisplay"] == 3
+
+
 @pytest.mark.parametrize("layer_class, data, ndim", layer_test_data)
 def test_attributes_for_all_layer_types(
     make_napari_viewer, layer_class, data, ndim

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -80,6 +80,7 @@ class FrameSequence(Sequence[ViewerState]):
         self.state_interpolation_map: InterpolationMap = {
             "camera.angles": Interpolation.SLERP,
             "camera.zoom": Interpolation.LOG,
+            "dims.ndisplay": Interpolation.BOOL,
         }
 
         # cache of interpolated viewer states

--- a/napari_animation/interpolation/interpolation_constants.py
+++ b/napari_animation/interpolation/interpolation_constants.py
@@ -2,6 +2,7 @@ from enum import Enum
 from functools import partial
 
 from .base_interpolation import default_interpolation as _default_interpolation
+from .base_interpolation import interpolate_bool as _interpolate_bool
 from .base_interpolation import interpolate_log as _interpolate_log
 from .base_interpolation import slerp as _slerp
 
@@ -13,12 +14,14 @@ class Interpolation(Enum):
         * DEFAULT: linear interpolation between start and endpoint.
         * SLERP: spherical linear interpolation on Euler angles.
         * LOG: log interpolation between start and endpoint.
+        * BOOL: boolean interpolation between start and endpoint.
 
     """
 
     DEFAULT = partial(_default_interpolation)
     LOG = partial(_interpolate_log)
     SLERP = partial(_slerp)
+    BOOL = partial(_interpolate_bool)
 
     def __call__(self, *args):
         return self.value(*args)


### PR DESCRIPTION
Closes: https://github.com/napari/napari-animation/issues/156

This PR adds `interpolate_bool` to the Interpolation ENUM and then uses that for interpolating `dims.ndisplay` because this can only be 2 or 3, behaving like a boolean, which is how all strings are interpolated.
Previously, the numeric interpolation was used because `ndisplay` type is int and so the outcome was cast to int, which truncated the decimal resulting in the opposite behavior from strings, making for a mismatch in the end behavior.

Try doing an animation where you change to 3D viewer and then rotate the object. On live, this won't result in the expected animation, but with this PR it will.

```
import napari
from napari_animation import Animation

viewer = napari.Viewer()
viewer.dims.ndisplay = 2
viewer.open_sample("napari", "binary_blobs_3D")
anim = Animation(viewer)
anim.capture_keyframe(steps=3)
viewer.dims.ndisplay = 3
viewer.camera.angles = (-30, 40, 15)
anim.capture_keyframe()
anim.animate("test.mp4")
```