### PR TITLE
[DOC] Warn about `ffmpeg` on arm64 macOS and add Conda to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ pip install napari-animation
 ```
 
 > [!WARNING]
-> `napari-animation` uses `ffmpeg` to export animations. If you are using a macOS arm64 computer (e.g. M1, M2 processor)
-> the PyPI package does not include the needed binary for your platform. You will need to install `ffmpeg` from using
+> `napari-animation` uses `ffmpeg` to export animations. If you are using a macOS arm64 computer (Apple Silicon e.g. M1, M2 processor)
+> the PyPI package does not include the needed binary for your platform. You will need to install `ffmpeg` using
 > `conda` from the [conda-forge channel](https://conda-forge.org/docs/#what-is-conda-forge) (`conda install -c conda-forge ffmpeg`)
 > or using [`homebrew`](https://brew.sh) (`brew install ffmpeg`).
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ This plugin remains under development and contributions are very welcome, please
 pip install napari-animation
 ```
 
+> [!WARNING]
+> `napari-animation` uses `ffmpeg` to export animations. If you are using a macOS arm64 computer (e.g. M1, M2 processor)
+> the PyPI package does not include the needed binary for your platform. You will need to install `ffmpeg` from using
+> `conda` from the [conda-forge channel](https://conda-forge.org/docs/#what-is-conda-forge) (`conda install -c conda-forge ffmpeg`)
+> or using [`homebrew`](https://brew.sh) (`brew install ffmpeg`).
+
+### Conda
+`napari-animation` is also available for install using `conda` through the [conda-forge channel](https://conda-forge.org/docs/#what-is-conda-forge).
+
+```sh
+conda install -c conda-forge napari-animation
+```
+
 ### Local
 You can clone this repository and install locally with
 


### PR DESCRIPTION
Closes: https://github.com/napari/napari-animation/issues/196

The PyPI package doesn't have an arm64 macOS binary for ffmpeg, so exporting animations doesn't work with a pip install. I've added a warning about this to the README and provide two ways to get arm64 ffmpeg installed which both work.
Additionally, add section for Conda installation.