### PR TITLE
[MAINT] Add python 3.11 to test matrix

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Test with tox
         uses: aganders3/headless-gui@v1
         with:
-            run: tox -a
+            run: tox
         env:
           PLATFORM: ${{ matrix.platform }}
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Test with tox
         uses: aganders3/headless-gui@v1
         with:
-            run: tox
+            run: tox -a
         env:
           PLATFORM: ${{ matrix.platform }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: isort
       exclude: _vendor|vendored|examples 
 -   repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 23.12.1
     hooks:
     - id: black
       pass_filenames: true

--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -152,7 +152,6 @@ class AnimationWidget(QWidget):
                 self.animation.set_movie_frame_index(frame_index)
 
     def _save_callback(self, event=None):
-
         saveDialogWidget = SaveDialogWidget(self)
         animation_kwargs = saveDialogWidget.getAnimationParameters(
             self, "Save animation", str(Path.home())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py38', 'py39', 'py310', 'py311']
 line-length = 79
 exclude = '''
 (

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}-{pyqt,pyside}
+envlist = py{38,39,310,311}-{linux,macos,windows}-{pyqt,pyside}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310,311}-{linux,macos,windows}-{pyqt,pyside}
+envlist = py{38,39,310,311}-{linux,macos,windows}-pyqt, py{38,39,310}-{linux,macos,windows}-pyside
 
 [gh-actions]
 python =
@@ -37,9 +37,15 @@ deps =
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/intro.html
     pytest-xvfb ; sys_platform == 'linux'
-    pyqt: napari[pyqt5,testing]
-    pyside: napari[pyside2,testing] ; python_version < '3.11'
 commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
+
+[testenv:pyqt]
+deps =
+    pyqt: napari[pyqt5,testing]
+
+[testenv:pyside]
+deps =
+    pyside: napari[pyside2,testing]
 
 [testenv:isort]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 deps =
     napari[pyqt5,testing]
 
-[testenv:py{38,39,310,311}-{linux,macos,windows}-pyside]
+[testenv:py{38,39,310}-{linux,macos,windows}-pyside]
 deps =
     napari[pyside2,testing]
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/intro.html
     pytest-xvfb ; sys_platform == 'linux'
     pyqt: napari[pyqt5,testing]
-    pyside: napari[pyside2,testing]
+    pyside: napari[pyside2,testing] ; python_version < '3.11'
 commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 
 [testenv:isort]

--- a/tox.ini
+++ b/tox.ini
@@ -39,11 +39,11 @@ deps =
     pytest-xvfb ; sys_platform == 'linux'
 commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 
-[testenv:pyqt]
+[testenv:py{38,39,310,311}-{linux,macos,windows}-pyqt]
 deps =
     napari[pyqt5,testing]
 
-[testenv:pyside]
+[testenv:py{38,39,310,311}-{linux,macos,windows}-pyside]
 deps =
     napari[pyside2,testing]
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,11 +41,11 @@ commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 
 [testenv:pyqt]
 deps =
-    pyqt: napari[pyqt5,testing]
+    napari[pyqt5,testing]
 
 [testenv:pyside]
 deps =
-    pyside: napari[pyside2,testing]
+    napari[pyside2,testing]
 
 [testenv:isort]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
     
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
Adding python 3.11 to test matrix, which has experimental support in napari.
Once napari drops python 3.8 (real soon now? see https://github.com/napari/napari/pull/5768 ) then we can also drop it here.
Note that pyside2 doesn't have any current wheels for python 3.11, so had to split pyqt and pyside testing to not run pyside2 with python 3.11
Also had to bump the black version to support python 3.11