### PR TITLE
add lxml_html_clean to testing in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ testing =
     pytest
     pytest-cov
     pytest-qt
+    # should only be needed till napari 0.5.0 release
     lxml_html_clean
 doc =
     sphinx>6

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ testing =
     pytest
     pytest-cov
     pytest-qt
+    lxml_html_clean
 doc =
     sphinx>6
     sphinx-autobuild

--- a/tox.ini
+++ b/tox.ini
@@ -32,16 +32,17 @@ deps =
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/intro.html
     pytest-xvfb ; sys_platform == 'linux'
-    lxml_html_clean # should only be needed till napari 0.5.0
 commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 
 [testenv:py{38,39,310,311}-{linux,macos,windows}-pyqt]
 deps =
     napari[pyqt5,testing]
+    lxml_html_clean # should only be needed till napari 0.5.0
 
 [testenv:py{38,39,310}-{linux,macos,windows}-pyside]
 deps =
     napari[pyside2,testing]
+    lxml_html_clean # should only be needed till napari 0.5.0
 
 [testenv:ruff]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/intro.html
     pytest-xvfb ; sys_platform == 'linux'
+    lxml_html_clean # should only be needed till napari 0.5.0
 commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 
 [testenv:py{38,39,310,311}-{linux,macos,windows}-pyqt]


### PR DESCRIPTION
Tests are failing because pytest appears to import a lot? so it picks up missing lxml_html_clean from napari
https://github.com/napari/napari-animation/actions/runs/8697301919/job/23852283978#step:7:108

Adding it to `testing` because it's not needed by anything in napari-animation. Actual use in napari is gated by try:
https://github.com/napari/napari/blob/dec8b09184728b632945ba09c7e6c8fe6c953508/napari/utils/notebook_display.py#L6-L9
But it's needed for napari tests so it's in napari[testing] but the fix isn't released yet.
