### PR TITLE
Switch to PyPI Trusted Publishing, and remove twine

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -93,7 +93,7 @@ jobs:
       id-token: write
     environment:
       name: pypi
-      url: https://pypi.org/p/<your-pypi-project-name>
+      url: https://pypi.org/project/napari-animation
     if: contains(github.ref, 'tags')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,10 +28,10 @@ jobs:
         task: [black, ruff]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,4 +1,4 @@
-# This workflows will upload a Python Package using Twine when a release is created
+# This workflows will upload a Python Package using Trusted Publishing when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: tests
@@ -84,10 +84,16 @@ jobs:
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
-    # and requires that you have put your twine API key in your 
-    # github secrets (see readme for details)
+    # and requires that you have setup PyPI Trusted Publishing
+    # (see https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
     needs: [ test ]
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<your-pypi-project-name>
     if: contains(github.ref, 'tags')
     steps:
       - uses: actions/checkout@v4
@@ -98,12 +104,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
+          pip install -U setuptools setuptools_scm wheel
+      - name: Build python package
         run: |
           git tag
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+      - name: Publish package distributions to PyPI
+        # This action uploads everything from the dist/ folder to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel
+          python -m pip install build setuptools setuptools_scm
       - name: Build python package
         run: |
           git tag

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Build python package
         run: |
           git tag
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Publish package distributions to PyPI
         # This action uploads everything from the dist/ folder to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ ignore = [
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]
 
-target-version = "py312"
+target-version = "py39"
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312']
 line-length = 79
 exclude = '''
 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ ignore = [
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]
 
-target-version = "py39"
+target-version = "py38"
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
+  "build",
   "setuptools >= 42",
-  "wheel",
   "setuptools_scm[toml]>=3.4"
 ]
 build-backend = "setuptools.build_meta"
@@ -53,5 +53,5 @@ ignore = [
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]
 
-target-version = "py38"
+target-version = "py312"
 fix = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,10 @@ classifiers =
     Framework :: napari
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Operating System :: OS Independent
     License :: OSI Approved :: BSD License
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310,311}-{linux,macos,windows}-pyqt, py{38,39,310}-{linux,macos,windows}-pyside
+envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310,311,312}-{linux,macos,windows}-pyside
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
-    
+    3.12: py312
+
 [gh-actions:env]
 PLATFORM =
     ubuntu-latest: linux
@@ -38,11 +38,13 @@ commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 deps =
     napari[pyqt5,testing]
     lxml_html_clean # should only be needed till napari 0.5.0
+    # .  # napari-animation install from source
 
 [testenv:py{38,39,310}-{linux,macos,windows}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0
+    # .  # napari-animation install from source
 
 [testenv:ruff]
 skip_install = True


### PR DESCRIPTION
Closes https://github.com/napari/napari-animation/issues/211

This PR switches to PyPI deployment with Trusted Publishing (see [the announcement](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) and [how trusted publishing works](https://docs.pypi.org/trusted-publishers/internals/)). It removes twine, and also removes the need for PyPI API tokens being used as github secrets.

This PR is not sufficient on its own, someone else also needs to:
* [Add a trusted publisher to our existing PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) (or you can [create a new PyPI project with a trusted publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)).
* Delete the old PyPI API tokens, from both PyPI and the GitHub repository secrets settings.