### PR TITLE
Ruff code formatting fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,6 +261,7 @@ def napari_scraper(block, block_vars, gallery_conf):
     for win, img_path in zip(
         reversed(napari._qt.qt_main_window._QtMainWindow._instances),
         imgpath_iter,
+        strict=False,
     ):
         img_paths.append(img_path)
         win._window.screenshot(img_path, canvas_only=False)

--- a/napari_animation/_tests/test_utils.py
+++ b/napari_animation/_tests/test_utils.py
@@ -5,7 +5,7 @@ from ..interpolation.utils import keys_to_list, nested_get
 input_dict = [{"a": 1, "b": {"c": "d"}}]
 keys = [["b", "c"]]
 expected = ["d"]
-test_set = list(zip(input_dict, keys, expected))
+test_set = list(zip(input_dict, keys, expected, strict=False))
 
 
 @pytest.mark.parametrize("input_dict,keys,expected", test_set)
@@ -16,7 +16,7 @@ def test_nested_get(input_dict, keys, expected):
 
 input_dict = [{"a": 1, "b": {"c": "d"}, "e": {}}]
 expected = [[["a"], ["b", "c"], ["e"]]]
-test_set = list(zip(input_dict, expected))
+test_set = list(zip(input_dict, expected, strict=False))
 
 
 @pytest.mark.parametrize("input_dict,expected", test_set)

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import TYPE_CHECKING, Dict, Iterator, Sequence, Tuple
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from napari.utils.events import EmitterGroup
@@ -84,10 +85,10 @@ class FrameSequence(Sequence[ViewerState]):
         }
 
         # cache of interpolated viewer states
-        self._cache: Dict[int, ViewerState] = LRUDict(cache_size=cache_size)
+        self._cache: dict[int, ViewerState] = LRUDict(cache_size=cache_size)
 
         # map of frame number -> (kf0, kf1, fraction)
-        self._keyframe_index: Dict[int, Tuple[KeyFrame, KeyFrame, float]] = {}
+        self._keyframe_index: dict[int, tuple[KeyFrame, KeyFrame, float]] = {}
         self._rebuild_keyframe_index()
 
     def _rebuild_keyframe_index(self, event=None):

--- a/napari_animation/interpolation/base_interpolation.py
+++ b/napari_animation/interpolation/base_interpolation.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from numbers import Integral, Number, Real
-from typing import Sequence, Tuple, TypeVar
+from typing import TypeVar
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R
@@ -31,7 +32,7 @@ def default_interpolation(a: _T, b: _T, fraction: float) -> _T:
     elif isinstance(a, Number) and isinstance(b, Number):
         return interpolate_num(a, b, fraction)
 
-    elif isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+    elif isinstance(a, list | tuple) and isinstance(b, list | tuple):
         return interpolate_sequence(a, b, fraction)
 
     else:
@@ -58,7 +59,10 @@ def interpolate_sequence(
     Interpolated sequence between a and b at fraction.
     """
     seq_cls = type(a)
-    gen = (default_interpolation(v0, v1, fraction) for v0, v1 in zip(a, b))
+    gen = (
+        default_interpolation(v0, v1, fraction)
+        for v0, v1 in zip(a, b, strict=False)
+    )
     try:
         seq = seq_cls(gen)
     except TypeError:
@@ -135,10 +139,10 @@ def interpolate_log(a: float, b: float, fraction: float) -> float:
 
 
 def slerp(
-    a: Tuple[float, float, float],
-    b: Tuple[float, float, float],
+    a: tuple[float, float, float],
+    b: tuple[float, float, float],
     fraction: float,
-) -> Tuple[float, float, float]:
+) -> tuple[float, float, float]:
     """Compute Spherical linear interpolation from Euler angles,
     compatible with the napari view.
 

--- a/napari_animation/interpolation/typing.py
+++ b/napari_animation/interpolation/typing.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from .interpolation_constants import Interpolation
 
-InterpolationMap = Dict[str, Interpolation]
+InterpolationMap = dict[str, Interpolation]

--- a/napari_animation/interpolation/utils.py
+++ b/napari_animation/interpolation/utils.py
@@ -81,8 +81,8 @@ def nested_assert_close(a, b):
 
 def nested_seq_assert_close(a, b):
     """Assert close to scalar or potentially nested qequences of numeric types and others."""
-    if isinstance(a, (list, tuple)) or isinstance(b, (list, tuple)):
-        for a_v, b_v in zip(a, b):
+    if isinstance(a, list | tuple) or isinstance(b, list | tuple):
+        for a_v, b_v in zip(a, b, strict=False):
             nested_seq_assert_close(a_v, b_v)
     else:
         if isinstance(a, Number):

--- a/napari_animation/utils.py
+++ b/napari_animation/utils.py
@@ -30,7 +30,7 @@ def pairwise(iterable):
     "s -> (s0,s1), (s1,s2), (s2, s3), ..."
     a, b = itertools.tee(iterable)
     next(b, None)
-    return zip(a, b)
+    return zip(a, b, strict=False)
 
 
 def layer_attribute_changed(value, original_value):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ ignore = [
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]
 
-target-version = "py312"
+target-version = "py39"
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ ignore = [
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]
 
-target-version = "py38"
+target-version = "py312"
 fix = true


### PR DESCRIPTION
This PR updates the version of python used to run the [ruff](https://github.com/astral-sh/ruff) code formatting check (since python 3.8 is nearing end of life), and updates the code for compliance with ruff's linting specifications.
