### PR TITLE
Exclude failing PySide CI tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -45,6 +45,19 @@ jobs:
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        # napari is experiencing CI failures with PySide backends
+        # on Windows platforms for all versions of python, and
+        # on all platforms with python 3.11
+        # See issues:
+        # Python 3.11 PySide problems https://github.com/napari/napari/issues/6381
+        # and https://github.com/napari/napari/issues/5884#issuecomment-1584160532
+        # Windows PySide problems https://github.com/napari/napari/pull/6721/files
+        # and https://github.com/napari/napari/pull/6711/
+        exclude:
+          - python: "3.11"
+            backend: pyside2
+          - platform: windows-latest
+            backend: pyside2
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The CI tests are failing. It seems that napari experiences similar CI failures with PySide backends, and has chosen to skip most CI checks involving Pyside. 

This PR adds a similar exclude statement to the napari-animation github actions workflow.

### More details
There are issues with PySide combined with python 3.11:
* https://github.com/napari/napari/issues/6381
* https://github.com/napari/napari/issues/5884#issuecomment-1584160532

And there are issues with PySide on Windows, see:
* https://github.com/napari/napari/pull/6721/files
* https://github.com/napari/napari/pull/6711/
