### PR TITLE
Fix failing CI tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           python-version: "3.x"
 
+      # Temporary fix for 'pip install imageio[ffmpeg]'
+      # not including the FFMPEG binary on Apple Silicon macs
+      # This step can be removed when issue is fixed in imageio-ffmpeg
+      # https://github.com/imageio/imageio-ffmpeg/issues/71
+      - name: brew install ffmpeg
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install ffmpeg
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -47,9 +57,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Upgrade to macos-latest when ffmpeg binaries are available for Mac arm-64
-        # https://github.com/imageio/imageio-ffmpeg/issues/71
-        platform: [ ubuntu-latest, windows-latest, macos-13 ]
+        # PySide currently unavailable for MacOS arm64, test with macos-13
+        platform: [ ubuntu-latest, windows-latest, macos-latest, macos-13 ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # cancel-in-progress: true
+  cancel-in-progress: true
 
 jobs:
   code:
@@ -53,6 +53,7 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,14 +33,6 @@ jobs:
         with:
           python-version: "3.x"
 
-      # Temporary fix for 'pip install imageio-ffmpeg'
-      # not including the FFMPEG binary on Apple Silicon macs
-      # This step can be removed when issue is fixed in imageio-ffmpeg
-      # https://github.com/imageio/imageio-ffmpeg/issues/71
-      - name: Setup FFmpeg
-        if: runner.os == 'macOS'
-        uses: AnimMouse/setup-ffmpeg@v1
-
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -57,7 +49,7 @@ jobs:
       matrix:
         # Upgrade to macos-latest when ffmpeg binaries are available for Mac arm-64
         # https://github.com/imageio/imageio-ffmpeg/issues/71
-        platform: [ ubuntu-latest, windows-latest, macos-13 ]
+        platform: [ ubuntu-latest, windows-latest, macos-latest, macos-13 ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,16 +28,27 @@ jobs:
         task: [black, ruff]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.x"
+
+      # Temporary fix for 'pip install imageio-ffmpeg'
+      # not including the FFMPEG binary on Apple Silicon macs
+      # This step can be removed when issue is fixed in imageio-ffmpeg
+      # https://github.com/imageio/imageio-ffmpeg/issues/71
+      - name: Setup FFmpeg
+        if: runner.os == 'macOS'
+        uses: AnimMouse/setup-ffmpeg@v1
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install tox
-      - name: Run task
+
+      - name: Run tox
         run: tox -e ${{ matrix.task }}
+  
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
@@ -63,6 +74,14 @@ jobs:
           git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
+
+      # Temporary fix for 'pip install imageio-ffmpeg'
+      # not including the FFMPEG binary on Apple Silicon macs
+      # This step can be removed when issue is fixed in imageio-ffmpeg
+      # https://github.com/imageio/imageio-ffmpeg/issues/71
+      - name: Setup FFmpeg
+        if: runner.os == 'macOS'
+        uses: AnimMouse/setup-ffmpeg@v1
 
       - name: Install dependencies
         run: |
@@ -92,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -45,7 +45,7 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         # Upgrade to macos-latest when ffmpeg binaries are available for Mac arm-64
         # https://github.com/imageio/imageio-ffmpeg/issues/71

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -49,6 +49,7 @@ jobs:
       matrix:
         # Upgrade to macos-latest when ffmpeg binaries are available for Mac arm-64
         # https://github.com/imageio/imageio-ffmpeg/issues/71
+        # and when PySide is made available for Apple Silicon macos arm64
         platform: [ ubuntu-latest, windows-latest, macos-13 ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         # Upgrade to macos-latest when ffmpeg binaries are available for Mac arm-64
         # https://github.com/imageio/imageio-ffmpeg/issues/71
-        platform: [ ubuntu-latest, windows-latest, macos-latest, macos-13 ]
+        platform: [ ubuntu-latest, windows-latest, macos-13 ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -55,7 +55,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ ubuntu-latest, windows-latest, macos-latest ]
+        # Upgrade to macos-latest when ffmpeg binaries are available for Mac arm-64
+        # https://github.com/imageio/imageio-ffmpeg/issues/71
+        platform: [ ubuntu-latest, windows-latest, macos-13 ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
@@ -75,14 +77,6 @@ jobs:
           git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
-
-      # Temporary fix for 'pip install imageio-ffmpeg'
-      # not including the FFMPEG binary on Apple Silicon macs
-      # This step can be removed when issue is fixed in imageio-ffmpeg
-      # https://github.com/imageio/imageio-ffmpeg/issues/71
-      - name: Setup FFmpeg
-        if: runner.os == 'macOS'
-        uses: AnimMouse/setup-ffmpeg@v1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # cancel-in-progress: true
 
 jobs:
   code:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,16 +33,6 @@ jobs:
         with:
           python-version: "3.x"
 
-      # Temporary fix for 'pip install imageio[ffmpeg]'
-      # not including the FFMPEG binary on Apple Silicon macs
-      # This step can be removed when issue is fixed in imageio-ffmpeg
-      # https://github.com/imageio/imageio-ffmpeg/issues/71
-      - name: brew install ffmpeg
-        if: runner.os == 'macOS'
-        run: |
-          brew update
-          brew install ffmpeg
-
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -57,8 +47,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PySide currently unavailable for MacOS arm64, test with macos-13
-        platform: [ ubuntu-latest, windows-latest, macos-latest, macos-13 ]
+        # Upgrade to macos-latest when ffmpeg binaries are available for Mac arm-64
+        # https://github.com/imageio/imageio-ffmpeg/issues/71
+        platform: [ ubuntu-latest, windows-latest, macos-13 ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312']
 line-length = 79
 exclude = '''
 (

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,10 @@ classifiers =
     Framework :: napari
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Operating System :: OS Independent
     License :: OSI Approved :: BSD License
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,10 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 include_package_data = True
 install_requires =
-	imageio
-	imageio-ffmpeg
+	imageio[ffmpeg]
 	napari>=0.4.19rc5
 	npe2
 	numpy

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,15 @@ deps =
     napari[pyqt5,testing]
     lxml_html_clean # should only be needed till napari 0.5.0
 
-[testenv:py{38,39,310}-{linux,macos,windows}-pyside]
+# napari is experiencing CI failures with PySide backends
+# on Windows platforms for all versions of python, and
+# on all platforms with python 3.11
+# See issues:
+# Python 3.11 PySide problems https://github.com/napari/napari/issues/6381
+# and https://github.com/napari/napari/issues/5884#issuecomment-1584160532
+# Windows PySide problems https://github.com/napari/napari/pull/6721/files
+# and https://github.com/napari/napari/pull/6711/
+[testenv:py{38,39,310}-{linux,macos}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310}-{linux,macos-intel}-pyside
+envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310}-{linux,macos}-pyside
 
 [gh-actions]
 python =
@@ -12,8 +12,7 @@ python =
 [gh-actions:env]
 PLATFORM =
     ubuntu-latest: linux
-    macos-latest: macos
-    macos-13: macos-intel  # PySide currently unavailable for MacOS arm64
+    macos-13: macos  # PySide currently unavailable for MacOS arm64
     windows-latest: windows
 
 [testenv]
@@ -49,7 +48,7 @@ deps =
 # and https://github.com/napari/napari/issues/5884#issuecomment-1584160532
 # Windows PySide problems https://github.com/napari/napari/pull/6721/files
 # and https://github.com/napari/napari/pull/6711/
-[testenv:py{39,310}-{linux,macos-intel}-pyside]
+[testenv:py{39,310}-{linux,macos}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310,311,312}-{linux,macos,windows}-pyside
+envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310,312}-{linux}-pyside
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310,311}-{linux,macos,windows}-pyqt, py{38,39,310}-{linux,macos,windows}-pyside
+envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310,311,312}-{linux,macos,windows}-pyside
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
     
 [gh-actions:env]
 PLATFORM =
@@ -34,7 +34,7 @@ deps =
     pytest-xvfb ; sys_platform == 'linux'
 commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 
-[testenv:py{38,39,310,311}-{linux,macos,windows}-pyqt]
+[testenv:py{39,310,311,312}-{linux,macos,windows}-pyqt]
 deps =
     napari[pyqt5,testing]
     lxml_html_clean # should only be needed till napari 0.5.0
@@ -47,7 +47,7 @@ deps =
 # and https://github.com/napari/napari/issues/5884#issuecomment-1584160532
 # Windows PySide problems https://github.com/napari/napari/pull/6721/files
 # and https://github.com/napari/napari/pull/6711/
-[testenv:py{38,39,310}-{linux,macos}-pyside]
+[testenv:py{39,310,312}-{linux,macos}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310}-{linux,macos}-pyside
+envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310}-{linux,macos-intel}-pyside
 
 [gh-actions]
 python =
@@ -12,7 +12,8 @@ python =
 [gh-actions:env]
 PLATFORM =
     ubuntu-latest: linux
-    macos-13: macos  # PySide currently unavailable for MacOS arm64
+    macos-latest: macos
+    macos-13: macos-intel  # PySide currently unavailable for MacOS arm64
     windows-latest: windows
 
 [testenv]
@@ -48,7 +49,7 @@ deps =
 # and https://github.com/napari/napari/issues/5884#issuecomment-1584160532
 # Windows PySide problems https://github.com/napari/napari/pull/6721/files
 # and https://github.com/napari/napari/pull/6711/
-[testenv:py{39,310}-{linux,macos}-pyside]
+[testenv:py{39,310}-{linux,macos-intel}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -42,12 +42,13 @@ deps =
 # napari is experiencing CI failures with PySide backends
 # on Windows platforms for all versions of python, and
 # on all platforms with python 3.11
+# Finally, PySide2 is not currently available for macos arm-64 machines.
 # See issues:
 # Python 3.11 PySide problems https://github.com/napari/napari/issues/6381
 # and https://github.com/napari/napari/issues/5884#issuecomment-1584160532
 # Windows PySide problems https://github.com/napari/napari/pull/6721/files
 # and https://github.com/napari/napari/pull/6711/
-[testenv:py{39,310,312}-{linux,macos}-pyside]
+[testenv:py{39,310,312}-{linux}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310,312}-{linux}-pyside
+envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310}-{linux,macos-intel}-pyside
 
 [gh-actions]
 python =
@@ -13,6 +13,7 @@ python =
 PLATFORM =
     ubuntu-latest: linux
     macos-latest: macos
+    macos-13: macos-intel  # PySide currently unavailable for MacOS arm64
     windows-latest: windows
 
 [testenv]
@@ -32,7 +33,7 @@ deps =
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/intro.html
     pytest-xvfb ; sys_platform == 'linux'
-commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
+commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml --pdb
 
 [testenv:py{39,310,311,312}-{linux,macos,windows}-pyqt]
 deps =
@@ -41,14 +42,14 @@ deps =
 
 # napari is experiencing CI failures with PySide backends
 # on Windows platforms for all versions of python, and
-# on all platforms with python 3.11
+# on all platforms with python greater than 3.10.
 # Finally, PySide2 is not currently available for macos arm-64 machines.
 # See issues:
 # Python 3.11 PySide problems https://github.com/napari/napari/issues/6381
 # and https://github.com/napari/napari/issues/5884#issuecomment-1584160532
 # Windows PySide problems https://github.com/napari/napari/pull/6721/files
 # and https://github.com/napari/napari/pull/6711/
-[testenv:py{39,310,312}-{linux}-pyside]
+[testenv:py{39,310}-{linux,macos-intel}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0


### PR DESCRIPTION
This PR:
1. Drops python 3.8, and adds python 3.12 to the CI test matrix
2. Pins macos-13, the latest Intel mac version, for the CI tests. PySide2 is unavailable for Apple Silicon mac, and `pip install imageio[ffmpeg]` also does not include the ffmpeg binary for Apple Silicon mac (but imageio can still work if you  install ffmpeg separately)
3. Skips PySide CI tests on Windows platforms, and on all platforms for python >3.10

napari is experiencing CI failures with PySide backends
on Windows platforms for all versions of python,
and on all platforms with python greater than 3.10.
Also, PySide2 is not currently available for macos arm-64 machines.

Python 3.11 PySide problems:
* https://github.com/napari/napari/issues/6381
* https://github.com/napari/napari/issues/5884#issuecomment-1584160532

Windows PySide problems:
* https://github.com/napari/napari/pull/6721/files
* https://github.com/napari/napari/pull/6711/

Previously:
* https://github.com/napari/napari-animation/pull/219