### PR TITLE
Fix failing CI tests (ffmpeg on apple silicon, PySide2 problems)

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,6 +42,7 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,10 +28,10 @@ jobs:
         task: [black, ruff]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.x"
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -64,6 +64,16 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
+      # Temporary fix for 'pip install imageio-ffmpeg'
+      # not including the FFMPEG binary on Apple Silicon macs
+      # This step can be removed when issue is fixed in imageio-ffmpeg
+      # https://github.com/imageio/imageio-ffmpeg/issues/71
+      - name: Setup FFmpeg
+        if: runner.name == 'macos-latest'
+        run: |
+          brew update
+          brew install ffmpeg
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,7 +42,7 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -70,7 +70,7 @@ jobs:
       # This step can be removed when issue is fixed in imageio-ffmpeg
       # https://github.com/imageio/imageio-ffmpeg/issues/71
       - name: Setup FFmpeg
-        if: runner.name == 'macos-latest'
+        if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
         run: |
           brew update
           brew install ffmpeg

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310,311}-{linux,macos,windows}-pyqt, py{38,39,310}-{linux,macos,windows}-pyside
+envlist = py{38,39,310,311}-{linux,macos,windows}-pyqt, py{38,39,310}-{linux,macosintel,windows}-pyside
 
 [gh-actions]
 python =
@@ -13,11 +13,13 @@ python =
 PLATFORM =
     ubuntu-latest: linux
     macos-latest: macos
+    macos-13: macosintel
     windows-latest: windows
 
 [testenv]
 platform = 
     macos: darwin
+    macosintel: darwin
     linux: linux
     windows: win32
 passenv = 
@@ -39,7 +41,7 @@ deps =
     napari[pyqt5,testing]
     lxml_html_clean # should only be needed till napari 0.5.0
 
-[testenv:py{38,39,310}-{linux,macos,windows}-pyside]
+[testenv:py{38,39,310}-{linux,macosintel,windows}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310,311}-{linux,macos,windows}-pyqt, py{38,39,310}-{linux,macosintel,windows}-pyside
+envlist = py{39,310,311,312}-{linux,macos,windows}-pyqt, py{39,310}-{linux,macosintel,windows}-pyside
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
     
 [gh-actions:env]
 PLATFORM =
@@ -36,12 +36,13 @@ deps =
     pytest-xvfb ; sys_platform == 'linux'
 commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 
-[testenv:py{38,39,310,311}-{linux,macos,windows}-pyqt]
+[testenv:py{39,310,311,312}-{linux,macos,windows}-pyqt]
 deps =
     napari[pyqt5,testing]
     lxml_html_clean # should only be needed till napari 0.5.0
 
-[testenv:py{38,39,310}-{linux,macosintel,windows}-pyside]
+# PySide2 unavailable on Mac apple silicon arm64, and for python >=3.11
+[testenv:py{39,310}-{linux,macosintel,windows}-pyside]
 deps =
     napari[pyside2,testing]
     lxml_html_clean # should only be needed till napari 0.5.0


### PR DESCRIPTION
In this PR:
1. `brew install ffmpeg` for Apple Silicon Mac arm64 runners on github actions, since imageio-ffmpeg does not provide ffmpeg binaries for Apple Silicon https://github.com/imageio/imageio-ffmpeg/issues/71
2. Restrict PySide tests to Mac Intel (not Apple Silicon), and for all operating systems python>=3.10. PySide is not available for these configurations.
3. Drop python 3.8, and add python 3.12 to the CI test matrix
