### PR TITLE
Update ruff linting to python 3.9

### DIFF
--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import TYPE_CHECKING, Dict, Iterator, Sequence, Tuple
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from napari.utils.events import EmitterGroup
@@ -84,10 +85,10 @@ class FrameSequence(Sequence[ViewerState]):
         }
 
         # cache of interpolated viewer states
-        self._cache: Dict[int, ViewerState] = LRUDict(cache_size=cache_size)
+        self._cache: dict[int, ViewerState] = LRUDict(cache_size=cache_size)
 
         # map of frame number -> (kf0, kf1, fraction)
-        self._keyframe_index: Dict[int, Tuple[KeyFrame, KeyFrame, float]] = {}
+        self._keyframe_index: dict[int, tuple[KeyFrame, KeyFrame, float]] = {}
         self._rebuild_keyframe_index()
 
     def _rebuild_keyframe_index(self, event=None):

--- a/napari_animation/interpolation/base_interpolation.py
+++ b/napari_animation/interpolation/base_interpolation.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from numbers import Integral, Number, Real
-from typing import Sequence, Tuple, TypeVar
+from typing import TypeVar
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R
@@ -135,10 +136,10 @@ def interpolate_log(a: float, b: float, fraction: float) -> float:
 
 
 def slerp(
-    a: Tuple[float, float, float],
-    b: Tuple[float, float, float],
+    a: tuple[float, float, float],
+    b: tuple[float, float, float],
     fraction: float,
-) -> Tuple[float, float, float]:
+) -> tuple[float, float, float]:
     """Compute Spherical linear interpolation from Euler angles,
     compatible with the napari view.
 

--- a/napari_animation/interpolation/typing.py
+++ b/napari_animation/interpolation/typing.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from .interpolation_constants import Interpolation
 
-InterpolationMap = Dict[str, Interpolation]
+InterpolationMap = dict[str, Interpolation]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ ignore = [
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]
 
-target-version = "py38"
+target-version = "py39"
 fix = true


### PR DESCRIPTION
This PR updates the ruff target to python 3.9
This matches the minimum version of python supported by napari-animation.