### PR TITLE
[bugfix] coerce as_layer_data_tuple from DeprecatingDict to dict for internal use

### DIFF
--- a/napari_animation/viewer_state.py
+++ b/napari_animation/viewer_state.py
@@ -30,7 +30,7 @@ class ViewerState:
     def from_viewer(cls, viewer: napari.viewer.Viewer):
         """Create a ViewerState from a viewer instance."""
         layers = {
-            layer.name: layer.as_layer_data_tuple()[1]
+            layer.name: dict(layer.as_layer_data_tuple()[1])
             for layer in viewer.layers
         }
         for layer_attributes in layers.values():


### PR DESCRIPTION
Closes: https://github.com/napari/napari-animation/issues/228

As of https://github.com/napari/napari/pull/6976 (0.5.0) `as_layer_data_tuple` doesn't return a dict anymore, but a `_DeprecatingDict`. This means that the checks that use `isinstance(foo, dict)` in ViewerState and in interpolation.utils fail.

This PR coerces the output of `as_layer_data_tuple` in ViewerState to avoid this issue. The alternative would be to change the checks for `dict` to MutableMapping or such.

See: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/DeprecatingDict.20not.20accepted.20in.20LayerDataTuple