### PR TITLE
[Maint] Update tox.ini to use proper testenv reps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,14 +38,16 @@ commands = pytest -v --color=yes --cov=napari_animation --cov-report=xml
 
 [testenv:py{39,310,311,312}-{linux,macos,windows}-pyqt]
 deps =
-    napari[pyqt5,testing]
+    {[testenv]deps}
+    napari[pyqt5]
     lxml_html_clean # should only be needed till napari 0.5.0
     # .  # napari-animation install from source
 
 # PySide2 unavailable on Mac apple silicon arm64, and for python >=3.11
 [testenv:py{39,310}-{linux,macosintel,windows}-pyside]
 deps =
-    napari[pyside2,testing]
+    {[testenv]deps}
+    napari[pyside2]
     lxml_html_clean # should only be needed till napari 0.5.0
     # .  # napari-animation install from source
 


### PR DESCRIPTION
napari dropped pytest-cov so using `napari[testing]` doesn't provide it, resulting in failed tests:
https://github.com/napari/napari-animation/actions/runs/10723680922/job/29737511848?pr=229#step:8:115
This should fix it by using the napari-animation [testenv] deps for all tests.