### PR TITLE
Fix for 0.5.2+

### DIFF
--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -46,6 +46,8 @@ class Animation:
 
         self.key_frames = KeyFrameList()
 
+        self._frames = FrameSequence(self.key_frames)
+
         self.key_frames.events.removed.connect(self._on_keyframe_removed)
 
         self.key_frames.events.changed.connect(self._on_keyframe_changed)
@@ -56,7 +58,7 @@ class Animation:
 
         self._keyframe_counter = count()  # track number of frames created
 
-        self._frames = FrameSequence(self.key_frames)
+
 
         self._filename = None
 


### PR DESCRIPTION
This PR is pointing place where animation code depends on events order.

After this fix, the code will, work with 0.5.2 but not earlier.

Closes #231

The alternative is to use `position='first`` when connecting event. But code that do not depend on callback order may be better. 