### PR TITLE
Drop inserting in capture (changing in-place) and instead just add and then remove frames

### DIFF
--- a/napari_animation/_qt/animation_widget.py
+++ b/napari_animation/_qt/animation_widget.py
@@ -114,7 +114,13 @@ class AnimationWidget(QWidget):
 
     def _replace_keyframe_callback(self, event=None):
         """Replace current key-frame with new view"""
-        self.animation.capture_keyframe(**self._input_state(), insert=False)
+        if self.animation.key_frames.selection.active:
+            self.animation.capture_keyframe(**self._input_state())
+            self.animation.key_frames.select_previous()
+            self.animation.key_frames.remove_selected()
+            self.animation.key_frames.select_next()
+        else:
+            raise ValueError("No selected keyframe to replace !")
 
     def _delete_keyframe_callback(self, event=None):
         """Delete current key-frame"""

--- a/napari_animation/_tests/test_animation.py
+++ b/napari_animation/_tests/test_animation.py
@@ -52,16 +52,6 @@ def test_set_to_key_frame(animation_with_key_frames):
         assert animation.key_frames.selection.active == animation.key_frames[i]
 
 
-def test_replace_keyframe(animation_with_key_frames):
-    """Test Animation.set_to_key_frame()"""
-    animation = animation_with_key_frames
-    assert len(animation.key_frames) == 2
-    animation.capture_keyframe(insert=False)
-    animation.capture_keyframe(insert=False)
-    animation.capture_keyframe(insert=False)
-    assert len(animation.key_frames) == 2
-
-
 def test_get_viewer_state(empty_animation):
     """Test ViewerState.from_viewer()"""
     animation = empty_animation

--- a/napari_animation/animation.py
+++ b/napari_animation/animation.py
@@ -2,6 +2,7 @@ import os
 from itertools import count
 from pathlib import Path
 from time import sleep
+from typing import Optional
 
 import imageio
 import numpy as np
@@ -61,9 +62,9 @@ class Animation:
         self._filename = None
 
     def capture_keyframe(
-        self, steps=15, ease=Easing.LINEAR, insert=True, position: int = None
+        self, steps=15, ease=Easing.LINEAR, position: Optional[int] = None
     ):
-        """Record current key-frame
+        """Record current key-frame and insert into list
 
         Parameters
         ----------
@@ -73,9 +74,6 @@ class Animation:
             If provided this method should make from `[0, 1]` to `[0, 1]` and will
             be used as an easing function for the transition between the last state
             and captured one.
-        insert : bool
-            If captured key-frame should insert into current list or replace the current
-            keyframe.
         position : int, optional
             If provided, place new frame at this index. By default, inserts at current
             active frame.
@@ -86,18 +84,12 @@ class Animation:
             if active_keyframe:
                 position = self.key_frames.index(active_keyframe)
             else:
-                if insert:
-                    position = -1
-                else:
-                    raise ValueError("No selected keyframe to replace !")
+                position = -1
 
         new_frame = KeyFrame.from_viewer(self.viewer, steps=steps, ease=ease)
         new_frame.name = f"Key Frame {next(self._keyframe_counter)}"
 
-        if insert:
-            self.key_frames.insert(position + 1, new_frame)
-        else:
-            self.key_frames[position] = new_frame
+        self.key_frames.insert(position + 1, new_frame)
 
     def set_to_keyframe(self, frame: int):
         """Set the viewer to a given key-frame


### PR DESCRIPTION
Closes: https://github.com/napari/napari-animation/issues/231

So in https://github.com/napari/napari/pull/7150 event handling order was changed in napari.
This is making the key frame list manipulations for inserting a replacement frame not work correctly when the list change event callbacks trigger. I tried passing `position='first'` in the `.connect()` in various places and could not get it to resolve properly -- it's events of the  SelectableEventedList, which are on the napari side I think.

I also tried to keep the name of the frame when `insert=False`, but the hash is still different so selection still fails.

In this PR I work around all this event stuff by removing the `insert` kwarg on `capture_frame` and no longer edit the frame in-place when replacing. Instead, the new frame is added and previous is removed.
Note that the frame number was already incrementing even when replacing a frame (insert=False) and because one can re-order frames, the numbers lose meaning.