### PR TITLE
Fix order of connection. Version 2

### DIFF
--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -69,8 +69,8 @@ class FrameSequence(Sequence[ViewerState]):
         super().__init__()
         self._key_frames = key_frames
         key_frames.events.inserted.connect(self._rebuild_keyframe_index)
-        key_frames.events.removed.connect(self._rebuild_keyframe_index)
-        key_frames.events.changed.connect(self._rebuild_keyframe_index)
+        key_frames.events.removed.connect(self._rebuild_keyframe_index, position='first')
+        key_frames.events.changed.connect(self._rebuild_keyframe_index, position='first')
         key_frames.events.reordered.connect(self._rebuild_keyframe_index)
 
         self.__current_index = 0

--- a/napari_animation/frame_sequence.py
+++ b/napari_animation/frame_sequence.py
@@ -69,8 +69,12 @@ class FrameSequence(Sequence[ViewerState]):
         super().__init__()
         self._key_frames = key_frames
         key_frames.events.inserted.connect(self._rebuild_keyframe_index)
-        key_frames.events.removed.connect(self._rebuild_keyframe_index, position='first')
-        key_frames.events.changed.connect(self._rebuild_keyframe_index, position='first')
+        key_frames.events.removed.connect(
+            self._rebuild_keyframe_index, position="first"
+        )
+        key_frames.events.changed.connect(
+            self._rebuild_keyframe_index, position="first"
+        )
         key_frames.events.reordered.connect(self._rebuild_keyframe_index)
 
         self.__current_index = 0


### PR DESCRIPTION
This PR is resolving the problem described in #231 by enforcing that `FrameSequence` events are connected before `Animation` events 

closes #231
closes #232
closes #233 