### PR TITLE
docs: document canvas_only kwarg

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ animation.capture_keyframe()
 animation.animate('demo.mov', canvas_only=False)
 ```
 
+### Canvas only
+
+Both the GUI and the programmatic API let you choose how much of the napari window
+is captured in the animation, via the `canvas_only` option.
+
+- `canvas_only=True` (the default) exports only the napari canvas, i.e. the layer
+  visualization area, without the surrounding viewer interface. This is useful for
+  clean animations that don't show the rest of the napari UI.
+- `canvas_only=False` includes the full napari viewer, capturing the surrounding
+  interface context as well.
+
+In the GUI Save dialog this corresponds to the **Canvas only** checkbox, which is
+enabled by default.
+
+Programmatically, pass `canvas_only` to `animate`:
+
+```python
+animation.animate("animation.mp4", canvas_only=True, fps=60)
+```
+
 ## Examples
 
 Examples can be found in our [Examples gallery](https://napari.org/napari-animation/gallery), generated from [our example scripts](https://github.com/napari/napari-animation/tree/main/examples). Simple examples for both interactive and headless

--- a/README.md
+++ b/README.md
@@ -93,25 +93,9 @@ animation.capture_keyframe()
 animation.animate('demo.mov', canvas_only=False)
 ```
 
-### Canvas only
-
-Both the GUI and the programmatic API let you choose how much of the napari window
-is captured in the animation, via the `canvas_only` option.
-
-- `canvas_only=True` (the default) exports only the napari canvas, i.e. the layer
-  visualization area, without the surrounding viewer interface. This is useful for
-  clean animations that don't show the rest of the napari UI.
-- `canvas_only=False` includes the full napari viewer, capturing the surrounding
-  interface context as well.
-
-In the GUI Save dialog this corresponds to the **Canvas only** checkbox, which is
-enabled by default.
-
-Programmatically, pass `canvas_only` to `animate`:
-
-```python
-animation.animate("animation.mp4", canvas_only=True, fps=60)
-```
+Set `canvas_only=True` to export only the napari canvas, or `False` to include the
+full viewer interface. In the GUI Save dialog this corresponds to the **Canvas only**
+checkbox, which is enabled by default.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Adds documentation for the `canvas_only` keyword argument, requested in #235.

A new **Canvas only** subsection in the README covers:

* What `canvas_only=True` does — exports only the napari canvas / layer visualization area without the surrounding viewer interface
* What `canvas_only=False` does — includes the full napari viewer / interface context
* How this maps to the **Canvas only** checkbox in the GUI Save dialog
* How to use `canvas_only` programmatically with `animation.animate(...)`

The change is docs-only and added to the README, which is included by `docs/index.md`.

Closes #235

## Verification

* Reviewed existing `canvas_only` usage in `animation.py`, `savedialog_widget.py`, and `viewer_state.py`
* Confirmed `docs/index.md` includes the README
* Verified the change is docs-only
