### PR TITLE
Fix layer planes example orientation

### DIFF
--- a/examples/layer_planes.py
+++ b/examples/layer_planes.py
@@ -9,6 +9,7 @@ import skimage
 import scipy
 
 viewer = napari.Viewer(ndisplay=3)
+viewer.camera.orientation = ('away', 'down', 'right')
 
 nuclei = skimage.data.cells3d()[:,1,...]
 denoised = scipy.ndimage.median_filter(nuclei, size=3)


### PR DESCRIPTION
## References and relevant issues

Closes #245

## Description

Set the layer planes example camera orientation explicitly to the pre-0.6 axis direction. napari 0.6 changed the default depth axis from `away` to `towards`, which mirrored the example relative to its intended camera path. Keeping the orientation local to this example restores the original animation without changing global viewer defaults.

## Verification

- Executed `examples/layer_planes.py` with napari 0.8.0 using the native macOS Qt backend
- Rendered all 121 frames and produced the complete MP4 successfully
- `uvx pre-commit run --files examples/layer_planes.py`
- `python -m compileall -q examples/layer_planes.py`

A full Sphinx Gallery run reached example execution locally, but macOS Qt offscreen OpenGL terminated in an unrelated earlier 3D example. The target example itself completed under the native backend.